### PR TITLE
Add .prettierrc file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "tabWidth": 4,
+    "semi": false,
+    "bracketSpacing": false
+}

--- a/packages/config/eslint/index.js
+++ b/packages/config/eslint/index.js
@@ -14,13 +14,8 @@ module.exports = {
         ecmaVersion: 2020,
     },
     rules: {
-        "@typescript-eslint/indent": ["error", 4],
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-unused-vars": ["warn", {"argsIgnorePattern": "^_"}],
-        "@typescript-eslint/object-curly-spacing": ["error", "never"],
-        "@typescript-eslint/semi": ["error", "never"],
-        "eol-last": ["error", "never"],
-        "no-multi-spaces": "error",
         "no-unused-vars": "warn",
         "no-restricted-imports": [
             "error",


### PR DESCRIPTION
Add a few rules in a new .prettierrc file. When prettier is the formatter in your code editor, code will be formatted based on that

---
_**Obsolete**_
_previously added eslint rules but removed them in favor of prettier_

Added some new eslint rules based on the files I viewed in the project:

Enforce indentation of 4 spaces
```
"@typescript-eslint/indent": ["error", 4]
```

<br/>

Enforce spacing with { } where `import {StringBuilder}` is valid while `import { StringBuilder }` is invalid

```
"@typescript-eslint/object-curly-spacing": ["error", "never"]
```

<br/>
Enforce no usage of semicolons

```
"@typescript-eslint/semi": ["error", "never"]
```

<br/>
Enforce no usage of multiple spaces in a row excluding indentation

```
"no-multi-spaces": "error"
```

<br/>
Disallow newlines at end of files

```
"eol-last": ["error", "never"]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a project formatting configuration enforcing 4-space indentation, no semicolons, and tightened bracket/whitespace rules for consistent formatting.
  * Applied minor formatting adjustments and line-ending normalization across files to align existing code with the new style settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->