### PR TITLE
Create certs folder if it does not exist in cert.sh

### DIFF
--- a/scripts/cert.sh
+++ b/scripts/cert.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 echo "mkcert localhost"
-cd certs && mkcert localhost || exit 1
+mkdir -p certs && cd certs && mkcert localhost || exit 1


### PR DESCRIPTION
When running `npm run cert`, this was my output:

```bash
> opendaw@0.0.0 cert
> bash ./scripts/cert.sh

mkcert localhost
./scripts/cert.sh: line 4: cd: certs: No such file or directory
```

Edited the line to create the `certs` directory if it does not exist before navigating to it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced certificate generation setup process to ensure required directories are properly created, preventing potential failures during local development environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->