### PR TITLE
Add mkcert detection with install hint when not found

### DIFF
--- a/scripts/cert.sh
+++ b/scripts/cert.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
-echo "mkcert localhost"
-mkdir -p certs && cd certs && mkcert localhost || exit 1
+
+echo "Generating mkcert for localhost"
+mkdir -p certs && cd certs
+
+if ! command -v mkcert >/dev/null 2>&1; then
+  echo "Error: mkcert not found. Install it: https://github.com/FiloSottile/mkcert" >&2
+  exit 1
+fi
+
+mkcert localhost


### PR DESCRIPTION
Add mkcert check; give users a hint on systems (e.g., Windows) where it isn’t installed by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented dependency validation checks with clear error messaging when required tools are unavailable.
  * Improved script workflow organization and execution reliability with better status communication.
  * Enhanced setup process messaging for improved clarity during initialization steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->