### PR TITLE
fix(timeline): allow AudioUnit reorder via right-click menu (closes #55)

### DIFF
--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/headers/TrackHeaderMenu.ts
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/headers/TrackHeaderMenu.ts
@@ -118,12 +118,12 @@ export const installTrackHeaderMenu = (service: StudioService,
                 }).setTriggerProcedure(() => editing.modify(() => audioUnitBoxAdapter.moveTrack(trackBoxAdapter, 1))),
                 MenuItem.default({
                     label: "AudioUnit 1 Up",
-                    selectable: audioUnitBoxAdapter.indexField.getValue() > 0 && false
+                    selectable: audioUnitBoxAdapter.indexField.getValue() > 0
                 }).setTriggerProcedure(() => editing.modify(() => audioUnitBoxAdapter.move(-1))),
                 MenuItem.default({
                     label: "AudioUnit 1 Down",
                     selectable: audioUnitBoxAdapter.indexField.getValue() < project.rootBoxAdapter.audioUnits.adapters()
-                        .filter(adapter => !adapter.isOutput).length - 1 && false
+                        .filter(adapter => !adapter.isOutput).length - 1
                 }).setTriggerProcedure(() => editing.modify(() => audioUnitBoxAdapter.move(1)))
             )),
         MenuItem.default({

--- a/packages/studio/adapters/src/IndexedBoxAdapterCollection.ts
+++ b/packages/studio/adapters/src/IndexedBoxAdapterCollection.ts
@@ -108,23 +108,21 @@ export class IndexedBoxAdapterCollection<A extends IndexedBoxAdapter, P extends 
     }
 
     moveIndex(startIndex: int, delta: int): void {
+        if (delta === 0) {return}
         const adapters = this.adapters()
         const adapter = adapters[startIndex]
+        const newIndex = clamp(startIndex + delta, 0, adapters.length - 1)
+        if (newIndex === startIndex) {return}
         if (delta < 0) {
-            const newIndex = clamp(startIndex + delta, 0, adapters.length - 1)
             for (let index = newIndex; index < startIndex; index++) {
                 adapters[index].indexField.setValue(index + 1)
             }
-            adapter.indexField.setValue(newIndex)
-        } else if (delta > 1) {
-            const newIndex = clamp(startIndex + (delta - 1), 0, adapters.length - 1)
+        } else {
             for (let index = startIndex; index < newIndex; index++) {
                 adapters[index + 1].indexField.setValue(index)
             }
-            adapter.indexField.setValue(newIndex)
-        } else {
-            console.warn(`moveIndex had no effect: startIndex: ${startIndex}, delta: ${delta}`)
         }
+        adapter.indexField.setValue(newIndex)
     }
 
     size(): int {return this.#entries.size()}


### PR DESCRIPTION
> ⚠️ **Disclosure: This is an AI-assisted PR.** Analysis and patch were generated with Claude. The fix has **not been manually reproduced in the running studio app** — see the "Testing" section. Reviewer judgement required before merge.

Closes #55.

## What's happening

Two coupled bugs prevented AudioUnit reordering:

### 1. `TrackHeaderMenu.ts` hard-disables the menu items

Lines 121 and 126 had `&& false` tacked onto the `selectable` expression of "AudioUnit 1 Up" / "AudioUnit 1 Down":

```ts
selectable: audioUnitBoxAdapter.indexField.getValue() > 0 && false
…
selectable: …filter(adapter => !adapter.isOutput).length - 1 && false
```

Permanently greys both items, matching @kaiartikkas's screenshot in the issue.

### 2. `IndexedBoxAdapterCollection.moveIndex` no-ops on single-step move-down

```ts
} else if (delta > 1) {                                       // ← should be > 0
    const newIndex = clamp(startIndex + (delta - 1), …)        // ← off by one
    …
} else {
    console.warn(`moveIndex had no effect: …`)
}
```

So `move(adapter, 1)` (the most common case) silently fell into the warn branch. The negative-direction path was symmetric and correct.

This is presumably why @andremichelle added `&& false` in [1a79a1c3d](https://github.com/andremichelle/openDAW/commit/1a79a1c3d) — defensive, while the move logic was broken.

## What this PR does

**`IndexedBoxAdapterCollection.moveIndex`** — refactor into one symmetric path:

```ts
moveIndex(startIndex: int, delta: int): void {
    if (delta === 0) {return}
    const adapters = this.adapters()
    const adapter = adapters[startIndex]
    const newIndex = clamp(startIndex + delta, 0, adapters.length - 1)
    if (newIndex === startIndex) {return}
    if (delta < 0) {
        for (let index = newIndex; index < startIndex; index++) {
            adapters[index].indexField.setValue(index + 1)
        }
    } else {
        for (let index = startIndex; index < newIndex; index++) {
            adapters[index + 1].indexField.setValue(index)
        }
    }
    adapter.indexField.setValue(newIndex)
}
```

- Drops the `console.warn` no-op path
- Shared `newIndex` clamp + early-out
- Two shift loops, one per direction (negative branch unchanged)

**`TrackHeaderMenu.ts`** — drop `&& false` from the two menu items, letting the existing endpoint checks (`indexField > 0` and `indexField < lastIndex`) handle greying.

## Testing

**Not manually verified in the running studio app.** What I did:

- Read both files end-to-end and traced the call chain (`TrackHeaderMenu` → `AudioUnitBoxAdapter.move` → `audioUnits.move` → `IndexedBoxAdapterCollection.moveIndex`)
- Hand-traced `moveIndex` for delta in {-2, -1, 0, 1, 2} on a 4-item collection to confirm the rewrite preserves the working negative case and fixes the positive case
- Confirmed the negative-delta branch behaviour is unchanged (same math, same shift loop)

**Maintainer should reproduce:** right-click a track header → Move → "AudioUnit 1 Up/Down". Items should be enabled (except at endpoints) and click should reorder. Suggest also checking that `Track 1 Up/Down` (sub-track reorder via `moveTrack` → same `move` method) still works, since both call paths share the rewritten code.

## Notes

- Conforms to the `CLAUDE.md` style guide (no `try/catch`, no `as any`, no `!` definite-assignment, no inline comments).
- Drag-to-reorder (the broader feature kaiartikkas asked for and you mentioned wanting to implement) is **not** part of this PR — this just restores the menu path.
- PR opened via the `RTHYMS` account due to current auth setup; commit author is `Pattermesh <pattermesh@gmail.com>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio unit movement in the timeline editor. Move up/down controls now properly enable based on position constraints instead of being universally disabled. Improved the index movement calculation for more reliable repositioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->