### PR TITLE
fix(softwareKeyboard): retain state between toggles

### DIFF
--- a/packages/app/studio/src/service/StudioService.ts
+++ b/packages/app/studio/src/service/StudioService.ts
@@ -5,6 +5,7 @@ import {
     Errors,
     Func,
     int,
+    clamp,
     isAbsent,
     MutableObservableOption,
     Notifier,
@@ -108,6 +109,11 @@ export class StudioService implements ProjectEnv {
             tempo: new DefaultObservableValue(false),
             signature: new DefaultObservableValue(false)
         }
+    } as const
+    readonly #softwareKeyboard = {
+        octave: new DefaultObservableValue(5, {guard: (value: number): number => clamp(value, 0, 10)}),
+        channel: new DefaultObservableValue(0, {guard: (value: number): number => clamp(value, 0, 15)}),
+        velocity: new DefaultObservableValue(100, {guard: (value: number): number => clamp(value, 0, 100)}),
     } as const
     readonly menu = populateStudioMenu(this)
     readonly panelLayout = new PanelContents(createPanelFactory(this))
@@ -455,7 +461,10 @@ export class StudioService implements ProjectEnv {
         } else {
             const element = SoftwareMIDIPanel({
                 lifecycle: this.#softwareKeyboardLifeCycle,
-                service: this
+                service: this,
+                octave: this.#softwareKeyboard.octave,
+                channel: this.#softwareKeyboard.channel,
+                velocity: this.#softwareKeyboard.velocity,
             })
             Surface.get(window).floating.appendChild(element)
             this.#softwareKeyboardLifeCycle.own(Terminable.create(() => element.remove()))

--- a/packages/app/studio/src/service/StudioService.ts
+++ b/packages/app/studio/src/service/StudioService.ts
@@ -5,7 +5,6 @@ import {
     Errors,
     Func,
     int,
-    clamp,
     isAbsent,
     MutableObservableOption,
     Notifier,

--- a/packages/app/studio/src/service/StudioService.ts
+++ b/packages/app/studio/src/service/StudioService.ts
@@ -110,11 +110,6 @@ export class StudioService implements ProjectEnv {
             signature: new DefaultObservableValue(false)
         }
     } as const
-    readonly #softwareKeyboard = {
-        octave: new DefaultObservableValue(5, {guard: (value: number): number => clamp(value, 0, 10)}),
-        channel: new DefaultObservableValue(0, {guard: (value: number): number => clamp(value, 0, 15)}),
-        velocity: new DefaultObservableValue(100, {guard: (value: number): number => clamp(value, 0, 100)}),
-    } as const
     readonly menu = populateStudioMenu(this)
     readonly panelLayout = new PanelContents(createPanelFactory(this))
     readonly spotlightDataSupplier = new SpotlightDataSupplier()
@@ -461,10 +456,7 @@ export class StudioService implements ProjectEnv {
         } else {
             const element = SoftwareMIDIPanel({
                 lifecycle: this.#softwareKeyboardLifeCycle,
-                service: this,
-                octave: this.#softwareKeyboard.octave,
-                channel: this.#softwareKeyboard.channel,
-                velocity: this.#softwareKeyboard.velocity,
+                service: this
             })
             Surface.get(window).floating.appendChild(element)
             this.#softwareKeyboardLifeCycle.own(Terminable.create(() => element.remove()))

--- a/packages/app/studio/src/ui/software-midi/SoftwareMIDIPanel.tsx
+++ b/packages/app/studio/src/ui/software-midi/SoftwareMIDIPanel.tsx
@@ -37,18 +37,18 @@ const className = Html.adoptStyleSheet(css, "SoftwareMIDIPanel")
 type Construct = {
     lifecycle: Lifecycle
     service: StudioService
+    octave: DefaultObservableValue<byte>
+    channel: DefaultObservableValue<byte>
+    velocity: DefaultObservableValue<byte>
 }
 
-export const SoftwareMIDIPanel = ({lifecycle, service}: Construct) => {
+export const SoftwareMIDIPanel = ({lifecycle, service, octave, channel, velocity}: Construct) => {
     const numKeys = 18
     const pianoLayout = new PianoRollLayout(0, numKeys - 1, {
         whiteKeys: {width: 23, height: 48},
         blackKeys: {width: 19, height: 24}
     })
     const {softwareMIDIInput} = MidiDevices
-    const octave = new DefaultObservableValue(5, {guard: (value: number): number => clamp(value, 0, 10)})
-    const channel = new DefaultObservableValue(0, {guard: (value: number): number => clamp(value, 0, 15)})
-    const velocity = new DefaultObservableValue(100, {guard: (value: number): number => clamp(value, 0, 100)})
     const svg: SVGElement = (<PianoRoll lifecycle={lifecycle} pianoLayout={pianoLayout}/>)
     const midiIndicator: DomElement = <Icon symbol={IconSymbol.Connected}/>
     const element: HTMLElement = <div className={className}>

--- a/packages/app/studio/src/ui/software-midi/SoftwareMIDIPanel.tsx
+++ b/packages/app/studio/src/ui/software-midi/SoftwareMIDIPanel.tsx
@@ -34,15 +34,15 @@ import {NoteShortcuts, SoftwareMIDIShortcuts} from "@/ui/shortcuts/SoftwareMIDIS
 
 const className = Html.adoptStyleSheet(css, "SoftwareMIDIPanel")
 
+const octave = new DefaultObservableValue(5, {guard: (value: number): number => clamp(value, 0, 10)}),
+const channel = new DefaultObservableValue(0, {guard: (value: number): number => clamp(value, 0, 15)}),
+const velocity =  new DefaultObservableValue(100, {guard: (value: number): number => clamp(value, 0, 100)}),
 type Construct = {
     lifecycle: Lifecycle
     service: StudioService
-    octave: DefaultObservableValue<byte>
-    channel: DefaultObservableValue<byte>
-    velocity: DefaultObservableValue<byte>
 }
 
-export const SoftwareMIDIPanel = ({lifecycle, service, octave, channel, velocity}: Construct) => {
+export const SoftwareMIDIPanel = ({lifecycle, service}: Construct) => {
     const numKeys = 18
     const pianoLayout = new PianoRollLayout(0, numKeys - 1, {
         whiteKeys: {width: 23, height: 48},

--- a/packages/app/studio/src/ui/software-midi/SoftwareMIDIPanel.tsx
+++ b/packages/app/studio/src/ui/software-midi/SoftwareMIDIPanel.tsx
@@ -34,9 +34,9 @@ import {NoteShortcuts, SoftwareMIDIShortcuts} from "@/ui/shortcuts/SoftwareMIDIS
 
 const className = Html.adoptStyleSheet(css, "SoftwareMIDIPanel")
 
-const octave = new DefaultObservableValue(5, {guard: (value: number): number => clamp(value, 0, 10)}),
-const channel = new DefaultObservableValue(0, {guard: (value: number): number => clamp(value, 0, 15)}),
-const velocity =  new DefaultObservableValue(100, {guard: (value: number): number => clamp(value, 0, 100)}),
+const octave = new DefaultObservableValue(5, {guard: (value: number): number => clamp(value, 0, 10)})
+const channel = new DefaultObservableValue(0, {guard: (value: number): number => clamp(value, 0, 15)})
+const velocity =  new DefaultObservableValue(100, {guard: (value: number): number => clamp(value, 0, 100)})
 type Construct = {
     lifecycle: Lifecycle
     service: StudioService


### PR DESCRIPTION
retain state of the on screen keyboard: channel, octave, and velocity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the internal handling of software MIDI controls while preserving existing behavior.
  * Octave, channel, and velocity inputs continue to control MIDI note playback and pitch mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->