### PR TITLE
fix(tests): copy file bytes instead of aliasing readFileSync(...).buffer

### DIFF
--- a/packages/app/wasm/test/automation-edit-no-survivor-push.test.ts
+++ b/packages/app/wasm/test/automation-edit-no-survivor-push.test.ts
@@ -15,7 +15,7 @@ const ODSL = path.resolve(__dirname, "../public/odsl/test.odsl")
 
 describe("editing one parameter touches no other plugin", () => {
     it("changing the delay's feedback pushes exactly one parameter", async () => {
-        const commits = readCommits(readFileSync(ODSL).buffer as ArrayBuffer)
+        const commits = readCommits(new Uint8Array(readFileSync(ODSL)).buffer as ArrayBuffer)
         const {engine, memory} = await loadFullEngine()
         const pushes = () => engine.param_push_count() >>> 0
         const {boxGraph: source} = ProjectSkeleton.decode(commits[0].payload)

--- a/packages/app/wasm/test/chain-edit-no-survivor-push.test.ts
+++ b/packages/app/wasm/test/chain-edit-no-survivor-push.test.ts
@@ -17,7 +17,7 @@ const ODSL = path.resolve(__dirname, "../public/odsl/test.odsl")
 
 describe("chain edit touches no existing plugin", () => {
     it("removing pushes no params; adding pushes only the joiner's", async () => {
-        const commits = readCommits(readFileSync(ODSL).buffer as ArrayBuffer)
+        const commits = readCommits(new Uint8Array(readFileSync(ODSL)).buffer as ArrayBuffer)
         const {engine, memory} = await loadFullEngine()
         const pushes = () => engine.param_push_count() >>> 0
         const builds = () => engine.device_build_count() >>> 0

--- a/packages/app/wasm/test/heap-cycle-probe.test.ts
+++ b/packages/app/wasm/test/heap-cycle-probe.test.ts
@@ -15,7 +15,7 @@ const CYCLES = 20
 
 describe("heap across sync-log cycles", () => {
     it("forward+rewind returns to the same heap_used after warm-up", async () => {
-        const commits = readCommits(readFileSync(ODSL).buffer as ArrayBuffer)
+        const commits = readCommits(new Uint8Array(readFileSync(ODSL)).buffer as ArrayBuffer)
         const {engine, memory, drainSamples} = await loadFullEngine()
         const {boxGraph: source} = ProjectSkeleton.decode(commits[0].payload)
         const steps = decodeSteps(commits)

--- a/packages/app/wasm/test/helpers/render-harness.ts
+++ b/packages/app/wasm/test/helpers/render-harness.ts
@@ -13,7 +13,7 @@ import {connectSyncToEngine} from "./connect-sync"
 const ODSL = path.resolve(__dirname, "../../public/odsl/test.odsl")
 
 export const buildProject = async () => {
-    const commits = readCommits(readFileSync(ODSL).buffer as ArrayBuffer)
+    const commits = readCommits(new Uint8Array(readFileSync(ODSL)).buffer as ArrayBuffer)
     const {engine, memory, drainSamples} = await loadFullEngine()
     const {boxGraph: source} = ProjectSkeleton.decode(commits[0].payload)
     const steps = decodeSteps(commits)

--- a/packages/app/wasm/test/instrument-disable-silences.test.ts
+++ b/packages/app/wasm/test/instrument-disable-silences.test.ts
@@ -17,7 +17,7 @@ const ODSL = path.resolve(__dirname, "../public/odsl/test.odsl")
 
 describe("disabling every instrument silences the project", () => {
     it("renders silent with all instruments off, audible again when re-enabled", async () => {
-        const commits = readCommits(readFileSync(ODSL).buffer as ArrayBuffer)
+        const commits = readCommits(new Uint8Array(readFileSync(ODSL)).buffer as ArrayBuffer)
         const {engine, memory, drainSamples} = await loadFullEngine()
         const {boxGraph: source} = ProjectSkeleton.decode(commits[0].payload)
         const steps = decodeSteps(commits)

--- a/packages/app/wasm/test/load-303-project.test.ts
+++ b/packages/app/wasm/test/load-303-project.test.ts
@@ -21,7 +21,7 @@ const SCRIPT_CONFIGS: Record<string, ScriptCompiler.Config> = {
 
 describe("load 303 project", () => {
     it("registers its scripted devices and renders audible output", async () => {
-        const arrayBuffer = readFileSync(OD).buffer as ArrayBuffer
+        const arrayBuffer = new Uint8Array(readFileSync(OD)).buffer as ArrayBuffer
         const {boxGraph} = ProjectSkeleton.decode(arrayBuffer)
 
         let scriptedDevices = 0

--- a/packages/app/wasm/test/render-smoke.test.ts
+++ b/packages/app/wasm/test/render-smoke.test.ts
@@ -15,7 +15,7 @@ const ODSL = path.resolve(__dirname, "../public/odsl/test.odsl")
 
 describe("render smoke", () => {
     it("the fully-built project produces audible output", async () => {
-        const commits = readCommits(readFileSync(ODSL).buffer as ArrayBuffer)
+        const commits = readCommits(new Uint8Array(readFileSync(ODSL)).buffer as ArrayBuffer)
         const {engine, memory, drainSamples} = await loadFullEngine()
         const {boxGraph: source} = ProjectSkeleton.decode(commits[0].payload)
         const steps = decodeSteps(commits)

--- a/packages/app/wasm/test/reorder-no-param-push.test.ts
+++ b/packages/app/wasm/test/reorder-no-param-push.test.ts
@@ -16,7 +16,7 @@ const ODSL = path.resolve(__dirname, "../public/odsl/test.odsl")
 
 describe("reorder touches no existing plugin", () => {
     it("toggling the reorder rebuilds nothing and re-pushes no parameters", async () => {
-        const commits = readCommits(readFileSync(ODSL).buffer as ArrayBuffer)
+        const commits = readCommits(new Uint8Array(readFileSync(ODSL)).buffer as ArrayBuffer)
         const {engine, memory} = await loadFullEngine()
         const builds = () => engine.device_build_count() >>> 0
         const pushes = () => engine.param_push_count() >>> 0

--- a/packages/app/wasm/test/reorder-no-rebuild.test.ts
+++ b/packages/app/wasm/test/reorder-no-rebuild.test.ts
@@ -19,7 +19,7 @@ const ODSL = path.resolve(__dirname, "../public/odsl/test.odsl")
 
 describe("reorder does not rebuild devices", () => {
     it("toggling the delay/gate reorder reuses the processors", async () => {
-        const commits = readCommits(readFileSync(ODSL).buffer as ArrayBuffer)
+        const commits = readCommits(new Uint8Array(readFileSync(ODSL)).buffer as ArrayBuffer)
         const {engine, memory, deviceBuilds} = await loadFullEngine()
         const {boxGraph: source} = ProjectSkeleton.decode(commits[0].payload)
         const steps = decodeSteps(commits)

--- a/packages/app/wasm/test/sample-disposal.test.ts
+++ b/packages/app/wasm/test/sample-disposal.test.ts
@@ -39,7 +39,7 @@ const tick = () => new Promise(resolve => setTimeout(resolve))
 
 describe("sample disposal", () => {
     it("frees sample PCM when the AudioFileBoxes are deleted on rewind", async () => {
-        const commits = readCommits(readFileSync(ODSL).buffer as ArrayBuffer)
+        const commits = readCommits(new Uint8Array(readFileSync(ODSL)).buffer as ArrayBuffer)
         const {engine, memory} = await loadEngine()
         const {boxGraph: source} = ProjectSkeleton.decode(commits[0].payload)
         const steps = decodeSteps(commits)

--- a/packages/app/wasm/test/sync-log-engine.test.ts
+++ b/packages/app/wasm/test/sync-log-engine.test.ts
@@ -36,7 +36,7 @@ const loadEngine = async (): Promise<{engine: EngineExports, memory: WebAssembly
 
 describe("sync-log engine: forward to end, backward to start", () => {
     it("the engine survives a full rewind", async () => {
-        const commits = readCommits(readFileSync(ODSL).buffer as ArrayBuffer)
+        const commits = readCommits(new Uint8Array(readFileSync(ODSL)).buffer as ArrayBuffer)
         const {engine, memory} = await loadEngine()
         const {boxGraph: source} = ProjectSkeleton.decode(commits[0].payload)
         const steps = decodeSteps(commits)

--- a/packages/app/wasm/test/sync-log-scrub.test.ts
+++ b/packages/app/wasm/test/sync-log-scrub.test.ts
@@ -34,7 +34,7 @@ const tick = () => new Promise(resolve => setTimeout(resolve))
 
 describe("sync-log scrub", () => {
     it("settles on the final target after a fast-scrub barrage, engine in sync", async () => {
-        const commits = readCommits(readFileSync(ODSL).buffer as ArrayBuffer)
+        const commits = readCommits(new Uint8Array(readFileSync(ODSL)).buffer as ArrayBuffer)
         const {engine, memory} = await loadEngine()
         const {boxGraph: source} = ProjectSkeleton.decode(commits[0].payload)
         const steps = decodeSteps(commits)

--- a/packages/app/wasm/test/sync-log.test.ts
+++ b/packages/app/wasm/test/sync-log.test.ts
@@ -12,7 +12,7 @@ const ODSL = path.resolve(__dirname, "../public/odsl/test.odsl")
 
 describe("sync-log navigation", () => {
     it("fast-forwards to the end and fully rewinds to the start", () => {
-        const commits = readCommits(readFileSync(ODSL).buffer as ArrayBuffer)
+        const commits = readCommits(new Uint8Array(readFileSync(ODSL)).buffer as ArrayBuffer)
         expect(commits.length).toBeGreaterThan(1)
         expect(commits[0].type).toBe(COMMIT_INIT)
         const {boxGraph} = ProjectSkeleton.decode(commits[0].payload)

--- a/packages/app/wasm/test/sync.test.ts
+++ b/packages/app/wasm/test/sync.test.ts
@@ -67,7 +67,7 @@ const checksumsEqual = (left: Int8Array, right: Int8Array): boolean =>
 
 describe("sync: actions.odsl -> SyncSource -> wasm engine (checksum per transaction)", () => {
     it("matches the engine checksum after every transaction", async () => {
-        const commits = readCommits(readFileSync(ODSL).buffer as ArrayBuffer)
+        const commits = readCommits(new Uint8Array(readFileSync(ODSL)).buffer as ArrayBuffer)
         expect(commits.length).toBeGreaterThan(1)
         expect(commits[0].type).toBe(COMMIT_INIT)
 


### PR DESCRIPTION
## Problem

`load-303-project.test.ts` (and 13 other wasm test sites) convert a file to an `ArrayBuffer` with:

```ts
readFileSync(OD).buffer as ArrayBuffer
```

`Buffer.prototype.buffer` returns the Buffer's *entire underlying* `ArrayBuffer`. Starting with newer Node 24.x (observed on 24.18.0; 24.11.0 is unaffected), `fs.readFileSync` reads small files into a shared 64 KB buffer pool, so the returned Buffer is a view at a nonzero `byteOffset`. `.buffer` then yields the whole pool — whose first bytes are whatever an earlier `readFileSync` in the same process put there — and `ProjectSkeleton.decode` panics with:

```
Error: Corrupt header. Probably not an openDAW project file.
```

Reproduction on Node 24.18.0:

```js
const fs = require("fs")
fs.readFileSync("package.json"); fs.readFileSync("turbo.json")
const b = fs.readFileSync("packages/app/wasm/public/projects/303.od")
// byteOffset 4200, pool 65536, len 30863
// first 4 bytes of b.buffer: "{\n  "  (leftover package.json, not "OPEN")
```

It's order-dependent in vitest: a worker that already ran another file-reading test has a shifted pool, which is why the failure appears in full-suite CI runs but not when a test file runs alone.

## Fix

Wrap the 14 single-expression sites in `new Uint8Array(...)` to take an exact-size copy before using `.buffer`:

```ts
new Uint8Array(readFileSync(OD)).buffer as ArrayBuffer
```

This is the same correctness guarantee as the `buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength)` pattern the multi-line call sites (e.g. `freeze-80s-full.test.ts`, `render-od.ts`) already use — those sites are untouched.

## Testing

All 13 affected test files pass on Node 24.18.0 and 24.11.0 after the change; before the change, the decode paths read pool garbage on 24.18.0 (verified with the reproduction above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved binary fixture loading across WASM test suites for more consistent project and commit parsing.
  - Preserved existing coverage for synchronization, rendering, editing, reordering, disposal, and engine behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->