### PR TITLE
fix(engine): data race on CURRENT_UNIT_NOTE_BITS crashes parallel cargo tests

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -463,14 +463,29 @@ pub(crate) static MONITOR_OUTPUT: Shared<[f32; monitor::MONITOR_CHANNELS * RENDE
 
 // The note-bits slot of the unit CURRENTLY reconciling (its instruments capture it at construction —
 // composite slots share their unit's slot). Set around `reconcile_one`'s chain work, cleared after.
+#[cfg(not(test))]
 static CURRENT_UNIT_NOTE_BITS: Shared<Option<engine_env::telemetry::BroadcastSlot>> = Shared::new(None);
+#[cfg(test)]
+std::thread_local! {
+    // Tests run on parallel threads; the production engine is single-threaded, so the Shared cell is only
+    // sound there. Per-thread isolation keeps the tests deterministic (the PARAMS_SIGNAL pattern): the
+    // slot holds an Rc, and racing its non-atomic refcount across test threads corrupts it.
+    static CURRENT_UNIT_NOTE_BITS: core::cell::RefCell<Option<engine_env::telemetry::BroadcastSlot>> =
+        const { core::cell::RefCell::new(None) };
+}
 
 pub(crate) fn current_unit_note_bits() -> Option<engine_env::telemetry::BroadcastSlot> {
-    unsafe { CURRENT_UNIT_NOTE_BITS.get() }.clone()
+    #[cfg(not(test))]
+    { unsafe { CURRENT_UNIT_NOTE_BITS.get() }.clone() }
+    #[cfg(test)]
+    { CURRENT_UNIT_NOTE_BITS.with(|cell| cell.borrow().clone()) }
 }
 
 pub(crate) fn set_current_unit_note_bits(slot: Option<engine_env::telemetry::BroadcastSlot>) {
-    *unsafe { CURRENT_UNIT_NOTE_BITS.get() } = slot;
+    #[cfg(not(test))]
+    unsafe { *CURRENT_UNIT_NOTE_BITS.get() = slot; }
+    #[cfg(test)]
+    CURRENT_UNIT_NOTE_BITS.with(|cell| *cell.borrow_mut() = slot);
 }
 
 /// One link in a unit's event PULL CHAIN (the `NoteEventSource` chain, sequencer -> fx -> ... -> the


### PR DESCRIPTION
## Problem

`cargo test -p engine --lib` segfaults intermittently (~1 in 10 runs locally, and flaky in CI — SIGSEGV on Linux, SIGABRT/SIGSEGV on macOS), aborting the whole test binary with no test output:

```
running 93 tests
error: test failed, to rerun pass `-p engine --lib`
Caused by:
  process didn't exit successfully: `.../deps/engine-...` (signal: 11, SIGSEGV: invalid memory reference)
```

The engine is single-threaded by contract, so `Shared<T>` (`UnsafeCell` + `unsafe impl Sync`) is sound in production. But libtest runs tests on parallel threads, and every test that reconciles a unit writes the same static:

```rust
static CURRENT_UNIT_NOTE_BITS: Shared<Option<engine_env::telemetry::BroadcastSlot>> = Shared::new(None);
```

`BroadcastSlot` holds an `Rc` — non-atomic refcounts. Concurrent clone/overwrite/drop through the static corrupts a refcount and a later drop frees garbage. macOS crash reports from stress runs show three *different* tests faulting, all with the same stack: `Engine::reconcile_one → set_current_unit_note_bits → Rc drop glue → KERN_INVALID_ADDRESS at 0x18`.

## Fix

Apply the same `#[cfg(test)] thread_local!` treatment `params.rs` already gives `PARAMS_SIGNAL` for exactly this reason ("Tests run on parallel threads; the production engine is single-threaded, so the Shared cell is only sound there") — `CURRENT_UNIT_NOTE_BITS` is set in the same function but never got the idiom. Production (wasm) code path is unchanged.

## Testing

- Before: ~1 in 10 `cargo test -p engine --lib` runs crash (macOS arm64 and Linux x64 CI, stable rustc).
- After: 0 crashes in 30 consecutive parallel runs; `cargo test --workspace` passes.

Possibly worth a look separately: `CURRENT_DEVICE_UUID` (`[u8; 16]`) and `FIELD_DELIVERIES` (`Vec`) are also raw `Shared` statics reachable from tests. Neither showed up in any crash report, but they race under the same conditions in principle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by isolating compiler state between threads.
  * Prevented cross-thread interference and refcount-related races during concurrent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->