### PR TITLE
Studio: Shared transport sync for Live Rooms (opt-in synced listening)

### DIFF
--- a/packages/app/studio/src/service/RoomAwareness.ts
+++ b/packages/app/studio/src/service/RoomAwareness.ts
@@ -14,6 +14,7 @@ export type AwarenessUserState = {
     name: string
     color: string
     panel: Nullable<string>
+    follow: boolean
 }
 
 export const readIdentity = (): { name: string, color: string } => {
@@ -42,6 +43,7 @@ export class RoomAwareness implements Terminable {
     readonly #name: DefaultObservableValue<string>
     readonly #color: DefaultObservableValue<string>
     readonly #panel: DefaultObservableValue<Nullable<string>>
+    readonly #follow: DefaultObservableValue<boolean>
 
     readonly #roomName: string
 
@@ -51,23 +53,27 @@ export class RoomAwareness implements Terminable {
         this.#name = this.#terminator.own(new DefaultObservableValue<string>(name))
         this.#color = this.#terminator.own(new DefaultObservableValue<string>(color))
         this.#panel = this.#terminator.own(new DefaultObservableValue<Nullable<string>>(null))
+        this.#follow = this.#terminator.own(new DefaultObservableValue<boolean>(false))
 
         const broadcast = this.#terminator.own(deferNextFrame(() => {
             const name = this.#name.getValue()
             const color = this.#color.getValue()
             const panel = this.#panel.getValue()
-            this.#awareness.setLocalStateField("user", {name, color, panel})
+            const follow = this.#follow.getValue()
+            this.#awareness.setLocalStateField("user", {name, color, panel, follow})
             writeIdentity(name, color)
         }))
         this.#terminator.own(this.#name.subscribe(broadcast.request))
         this.#terminator.own(this.#color.subscribe(broadcast.request))
         this.#terminator.own(this.#panel.subscribe(broadcast.request))
+        this.#terminator.own(this.#follow.subscribe(broadcast.request))
         broadcast.request()
     }
 
     get name(): MutableObservableValue<string> {return this.#name}
     get color(): MutableObservableValue<string> {return this.#color}
     get panel(): MutableObservableValue<Nullable<string>> {return this.#panel}
+    get follow(): MutableObservableValue<boolean> {return this.#follow}
     get roomName(): string {return this.#roomName}
     get awareness(): Awareness {return this.#awareness}
     get clientID(): number {return this.#awareness.clientID}

--- a/packages/app/studio/src/service/StudioLiveRoomConnect.ts
+++ b/packages/app/studio/src/service/StudioLiveRoomConnect.ts
@@ -8,6 +8,7 @@ import {RoomAwareness, writeIdentity} from "@/service/RoomAwareness"
 import {newRoomSessionId, reportRoomResult, RoomResultStatus, startRoomDurationHeartbeat} from "@/service/RoomStatsReporter"
 import {ChatService} from "@/chat/ChatService"
 import {Events} from "@opendaw/lib-dom"
+import {TransportYjsChannel} from "@/service/transport-sync/TransportYjsChannel"
 
 const classifyConnectError = (error: unknown): RoomResultStatus => {
     if (Errors.isAbort(error)) {return "abort"}
@@ -68,6 +69,7 @@ export const connectRoom = async (service: StudioService, prefillRoomName?: Opti
         terminator.own({terminate: () => window.removeEventListener("pagehide", pagehideHandler)})
         const roomAwareness = new RoomAwareness(provider.awareness, roomName, userName, userColor)
         terminator.own(roomAwareness)
+        terminator.own(service.transportSync.follow.catchupAndSubscribe(owner => roomAwareness.follow.setValue(owner.getValue())))
         terminator.own(Events.subscribe(window, "pointermove", (event: PointerEvent) => {
             const target = event.target
             if (target instanceof Element) {
@@ -111,6 +113,7 @@ export const connectRoom = async (service: StudioService, prefillRoomName?: Opti
         terminator.own(chatService)
         service.chatService.wrap(chatService)
         terminator.own({terminate: () => service.chatService.clear()})
+        terminator.own(service.transportSync.attach(new TransportYjsChannel(provider.doc)))
         await Wait.timeSpan(TimeSpan.seconds(1))
     } else {
         reportRoomResult(sessionId, classifyConnectError(error))

--- a/packages/app/studio/src/service/StudioService.ts
+++ b/packages/app/studio/src/service/StudioService.ts
@@ -78,6 +78,7 @@ import {ShadertoyState} from "@/ui/shadertoy/ShadertoyState"
 import {CodeEditorState} from "@/ui/code-editor/CodeEditorState"
 import {RoomAwareness} from "@/service/RoomAwareness"
 import {ChatService} from "@/chat/ChatService"
+import {TransportSyncService} from "@/service/transport-sync/TransportSyncService"
 
 /**
  * I am just piling stuff after stuff in here to boot the environment.
@@ -115,6 +116,7 @@ export class StudioService implements ProjectEnv {
     readonly samplePlayback: SamplePlayback
     readonly recovery = new Recovery(() => this.#projectProfileService.getValue(), this)
     readonly engine = new EngineFacade()
+    readonly transportSync = new TransportSyncService(this.engine)
     readonly presets = new PresetService(this)
 
     readonly #softwareKeyboardLifeCycle = new Terminator()

--- a/packages/app/studio/src/service/StudioShortcutManager.ts
+++ b/packages/app/studio/src/service/StudioShortcutManager.ts
@@ -109,8 +109,12 @@ export namespace StudioShortcutManager {
                 const {engine} = service
                 const isPlaying = engine.isPlaying.getValue()
                 if (isPlaying) {engine.stop()} else {engine.play()}
+                service.transportSync.publishLocal(!isPlaying)
             }),
-            gc.register(gs["stop-playback"].shortcut, () => engine.stop(true)),
+            gc.register(gs["stop-playback"].shortcut, () => {
+                engine.stop(true)
+                service.transportSync.publishLocal(false)
+            }),
             gc.register(gs["start-recording"].shortcut, () => {
                 if (isCountingIn.getValue()) {
                     engine.stop()

--- a/packages/app/studio/src/service/transport-sync/TransportAnchor.ts
+++ b/packages/app/studio/src/service/transport-sync/TransportAnchor.ts
@@ -1,0 +1,16 @@
+import {bpm, ppqn, PPQN} from "@opendaw/lib-dsp"
+
+// Phase 1 prototype (see plans/opendaw-shared-transport-plan.md): a shared anchor that
+// each client uses to independently recompute its own playback position, instead of
+// negotiating a continuous clock. `epoch` is Date.now() when the anchor was set.
+export type TransportAnchor = {
+    playing: boolean
+    epoch: number
+    anchorPosition: ppqn
+    bpm: bpm
+}
+
+export const TransportAnchor = {
+    recompute: (anchor: TransportAnchor, now: number = Date.now()): ppqn =>
+        anchor.playing ? anchor.anchorPosition + PPQN.secondsToPulses((now - anchor.epoch) / 1000, anchor.bpm) : anchor.anchorPosition
+} as const

--- a/packages/app/studio/src/service/transport-sync/TransportBroadcastChannel.ts
+++ b/packages/app/studio/src/service/transport-sync/TransportBroadcastChannel.ts
@@ -1,0 +1,22 @@
+import {Procedure, Subscription} from "@opendaw/lib-std"
+import {TransportAnchor} from "@/service/transport-sync/TransportAnchor"
+import {TransportChannel} from "@/service/transport-sync/TransportChannel"
+
+// Phase 1 prototype channel: BroadcastChannel gives every same-origin tab an in-memory shared
+// anchor with zero server/networking code. Superseded by TransportYjsChannel for real live-room
+// participants, kept here for same-browser testing without a room.
+export class TransportBroadcastChannel implements TransportChannel {
+    readonly #channel: BroadcastChannel
+
+    constructor(channelName: string) {this.#channel = new BroadcastChannel(channelName)}
+
+    publish(anchor: TransportAnchor): void {this.#channel.postMessage(anchor)}
+
+    subscribe(observer: Procedure<TransportAnchor>): Subscription {
+        const listener = (event: MessageEvent<TransportAnchor>) => observer(event.data)
+        this.#channel.addEventListener("message", listener)
+        return {terminate: () => this.#channel.removeEventListener("message", listener)}
+    }
+
+    terminate(): void {this.#channel.close()}
+}

--- a/packages/app/studio/src/service/transport-sync/TransportChannel.ts
+++ b/packages/app/studio/src/service/transport-sync/TransportChannel.ts
@@ -1,0 +1,9 @@
+import {Procedure, Subscription, Terminable} from "@opendaw/lib-std"
+import {TransportAnchor} from "@/service/transport-sync/TransportAnchor"
+
+// Implemented by whatever carries the shared anchor: BroadcastChannel for the phase 1
+// same-browser prototype, a Yjs `transport` Y.Map for real live-room participants.
+export interface TransportChannel extends Terminable {
+    publish(anchor: TransportAnchor): void
+    subscribe(observer: Procedure<TransportAnchor>): Subscription
+}

--- a/packages/app/studio/src/service/transport-sync/TransportSyncService.ts
+++ b/packages/app/studio/src/service/transport-sync/TransportSyncService.ts
@@ -1,6 +1,7 @@
 import {DefaultObservableValue, isDefined, Option, Optional, Subscription, Terminable, Terminator} from "@opendaw/lib-std"
 import {ppqn, PPQN} from "@opendaw/lib-dsp"
 import {Engine} from "@opendaw/studio-core"
+import {deferNextFrame, DeferExec} from "@opendaw/lib-dom"
 import {TransportAnchor} from "@/service/transport-sync/TransportAnchor"
 import {TransportChannel} from "@/service/transport-sync/TransportChannel"
 
@@ -22,17 +23,47 @@ export class TransportSyncService implements Terminable {
     readonly #follow = new DefaultObservableValue(false)
     readonly #rejoinGrid = new DefaultObservableValue<RejoinGrid>("bar")
 
+    readonly #positionBroadcast: DeferExec
+
     #channel: Option<TransportChannel> = Option.None
     #channelSubscription: Option<Subscription> = Option.None
     #latestAnchor: Option<TransportAnchor> = Option.None
     #rejoinTimeoutId: Optional<number> = undefined
     #driftIntervalId: Optional<number> = undefined
+    #applyingRemote: boolean = false
+    #tickPosition: Optional<ppqn> = undefined
+    #tickTimestamp: Optional<number> = undefined
 
     constructor(engine: Engine) {
         this.#engine = engine
+        this.#positionBroadcast = this.#terminator.own(deferNextFrame(() => this.publishLocal(true)))
         this.#terminator.own(this.#follow.subscribe(owner => {
             if (owner.getValue()) {this.#latestAnchor.ifSome(anchor => this.#reconcile(anchor))}
             else {this.#cancelRejoin(); this.#cancelDriftWatch()}
+        }))
+        // `engine.position` ticks continuously during normal playback (every engine state message),
+        // not just on seeks, so we can't republish on every change. Instead compare against where
+        // playback should naturally be since the last tick; a local seek (dragging the ruler,
+        // jump-to-grid, etc.) shows up as a jump far outside that expectation and re-anchors the
+        // stream — otherwise followers keep extrapolating from the pre-seek position. The baseline
+        // is still updated while #applyingRemote (this service itself following someone else's
+        // anchor), just without triggering a broadcast, so the tick right after isn't mistaken for
+        // a fresh local seek.
+        this.#terminator.own(this.#engine.position.subscribe(() => {
+            const isPlaying = this.#engine.isPlaying.getValue()
+            if (!isPlaying) {this.#tickPosition = undefined; this.#tickTimestamp = undefined; return}
+            const now = Date.now()
+            const actual = this.#engine.position.getValue()
+            if (!this.#applyingRemote && this.#channel.nonEmpty()
+                && isDefined(this.#tickPosition) && isDefined(this.#tickTimestamp)) {
+                const bpm = this.#engine.bpm.getValue()
+                const expected = this.#tickPosition + PPQN.secondsToPulses((now - this.#tickTimestamp) / 1000, bpm)
+                if (Math.abs(PPQN.pulsesToSeconds(actual - expected, bpm) * 1000) > ToleranceMillis) {
+                    this.#positionBroadcast.request()
+                }
+            }
+            this.#tickPosition = actual
+            this.#tickTimestamp = now
         }))
     }
 
@@ -82,8 +113,10 @@ export class TransportSyncService implements Terminable {
     }
 
     #snapToAnchor(anchor: TransportAnchor): void {
+        this.#applyingRemote = true
         this.#engine.setPosition(TransportAnchor.recompute(anchor, Date.now()))
         if (!this.#engine.isPlaying.getValue()) {this.#engine.play()}
+        this.#applyingRemote = false
         this.#ensureDriftWatch()
     }
 
@@ -97,7 +130,9 @@ export class TransportSyncService implements Terminable {
         const delayMillis = PPQN.pulsesToSeconds(nextGridLine - localPosition, anchor.bpm) * 1000
         this.#rejoinTimeoutId = window.setTimeout(() => {
             this.#rejoinTimeoutId = undefined
+            this.#applyingRemote = true
             this.#engine.setPosition(TransportAnchor.recompute(anchor, Date.now()))
+            this.#applyingRemote = false
             this.#ensureDriftWatch()
         }, delayMillis)
     }

--- a/packages/app/studio/src/service/transport-sync/TransportSyncService.ts
+++ b/packages/app/studio/src/service/transport-sync/TransportSyncService.ts
@@ -1,0 +1,129 @@
+import {DefaultObservableValue, isDefined, Option, Optional, Subscription, Terminable, Terminator} from "@opendaw/lib-std"
+import {ppqn, PPQN} from "@opendaw/lib-dsp"
+import {Engine} from "@opendaw/studio-core"
+import {TransportAnchor} from "@/service/transport-sync/TransportAnchor"
+import {TransportChannel} from "@/service/transport-sync/TransportChannel"
+
+const ToleranceMillis = 175
+const DriftCheckIntervalMillis = 500
+
+export type RejoinGrid = "bar" | "beat"
+
+const RejoinGridPulses: Readonly<Record<RejoinGrid, ppqn>> = {bar: PPQN.Bar, beat: PPQN.Quarter}
+
+// Shared listening (plans/opendaw-shared-transport-plan.md). Last action wins: whoever calls
+// play()/stop() locally publishes a fresh anchor. Clients that opt in via `follow` recompute
+// their own position from that anchor instead of receiving a running clock. The service itself
+// outlives any single room — call attach() with a channel (a live-room Y.Map, or the phase 1
+// BroadcastChannel) when one becomes available, and terminate the returned handle to detach.
+export class TransportSyncService implements Terminable {
+    readonly #terminator = new Terminator()
+    readonly #engine: Engine
+    readonly #follow = new DefaultObservableValue(false)
+    readonly #rejoinGrid = new DefaultObservableValue<RejoinGrid>("bar")
+
+    #channel: Option<TransportChannel> = Option.None
+    #channelSubscription: Option<Subscription> = Option.None
+    #latestAnchor: Option<TransportAnchor> = Option.None
+    #rejoinTimeoutId: Optional<number> = undefined
+    #driftIntervalId: Optional<number> = undefined
+
+    constructor(engine: Engine) {
+        this.#engine = engine
+        this.#terminator.own(this.#follow.subscribe(owner => {
+            if (owner.getValue()) {this.#latestAnchor.ifSome(anchor => this.#reconcile(anchor))}
+            else {this.#cancelRejoin(); this.#cancelDriftWatch()}
+        }))
+    }
+
+    get follow(): DefaultObservableValue<boolean> {return this.#follow}
+    get rejoinGrid(): DefaultObservableValue<RejoinGrid> {return this.#rejoinGrid}
+
+    attach(channel: TransportChannel): Terminable {
+        this.#detach()
+        this.#channel = Option.wrap(channel)
+        this.#channelSubscription = Option.wrap(channel.subscribe(anchor => this.#onRemoteAnchor(anchor)))
+        return {terminate: () => this.#detach()}
+    }
+
+    #detach(): void {
+        this.#channelSubscription.ifSome(subscription => subscription.terminate())
+        this.#channelSubscription = Option.None
+        this.#channel = Option.None
+        this.#latestAnchor = Option.None
+        this.#cancelRejoin()
+        this.#cancelDriftWatch()
+    }
+
+    publishLocal(playing: boolean): void {
+        const anchor: TransportAnchor = {
+            playing, epoch: Date.now(), anchorPosition: this.#engine.position.getValue(), bpm: this.#engine.bpm.getValue()
+        }
+        this.#latestAnchor = Option.wrap(anchor)
+        this.#channel.ifSome(channel => channel.publish(anchor))
+    }
+
+    #onRemoteAnchor(anchor: TransportAnchor): void {
+        this.#latestAnchor = Option.wrap(anchor)
+        if (this.#follow.getValue()) {this.#reconcile(anchor)}
+    }
+
+    #reconcile(anchor: TransportAnchor): void {
+        this.#cancelRejoin()
+        if (!anchor.playing) {this.#cancelDriftWatch(); this.#engine.stop(); return}
+        if (!this.#engine.isPlaying.getValue()) {this.#snapToAnchor(anchor); return}
+        if (Math.abs(this.#driftMillis(anchor)) > ToleranceMillis) {this.#scheduleQuantizedRejoin(anchor)} else {this.#ensureDriftWatch()}
+    }
+
+    #driftMillis(anchor: TransportAnchor): number {
+        const target = TransportAnchor.recompute(anchor, Date.now())
+        const local = this.#engine.position.getValue()
+        return PPQN.pulsesToSeconds(local - target, anchor.bpm) * 1000
+    }
+
+    #snapToAnchor(anchor: TransportAnchor): void {
+        this.#engine.setPosition(TransportAnchor.recompute(anchor, Date.now()))
+        if (!this.#engine.isPlaying.getValue()) {this.#engine.play()}
+        this.#ensureDriftWatch()
+    }
+
+    // Rather than yanking the playhead mid-grid-line (an audible glitch), wait for the next local
+    // bar or beat line and snap there — the "quantized rejoin" behaviour from the design doc.
+    #scheduleQuantizedRejoin(anchor: TransportAnchor): void {
+        this.#cancelDriftWatch()
+        const gridPulses = RejoinGridPulses[this.#rejoinGrid.getValue()]
+        const localPosition = this.#engine.position.getValue()
+        const nextGridLine = (Math.floor(localPosition / gridPulses) + 1) * gridPulses
+        const delayMillis = PPQN.pulsesToSeconds(nextGridLine - localPosition, anchor.bpm) * 1000
+        this.#rejoinTimeoutId = window.setTimeout(() => {
+            this.#rejoinTimeoutId = undefined
+            this.#engine.setPosition(TransportAnchor.recompute(anchor, Date.now()))
+            this.#ensureDriftWatch()
+        }, delayMillis)
+    }
+
+    #ensureDriftWatch(): void {
+        if (isDefined(this.#driftIntervalId)) {return}
+        this.#driftIntervalId = window.setInterval(() => {
+            if (!this.#follow.getValue()) {this.#cancelDriftWatch(); return}
+            this.#latestAnchor.ifSome(anchor => {
+                if (anchor.playing && this.#engine.isPlaying.getValue() && Math.abs(this.#driftMillis(anchor)) > ToleranceMillis) {
+                    this.#scheduleQuantizedRejoin(anchor)
+                }
+            })
+        }, DriftCheckIntervalMillis)
+    }
+
+    #cancelRejoin(): void {
+        if (isDefined(this.#rejoinTimeoutId)) {window.clearTimeout(this.#rejoinTimeoutId); this.#rejoinTimeoutId = undefined}
+    }
+
+    #cancelDriftWatch(): void {
+        if (isDefined(this.#driftIntervalId)) {window.clearInterval(this.#driftIntervalId); this.#driftIntervalId = undefined}
+    }
+
+    terminate(): void {
+        this.#detach()
+        this.#terminator.terminate()
+    }
+}

--- a/packages/app/studio/src/service/transport-sync/TransportYjsChannel.ts
+++ b/packages/app/studio/src/service/transport-sync/TransportYjsChannel.ts
@@ -1,0 +1,45 @@
+import {isDefined, Nullable, Procedure, Subscription} from "@opendaw/lib-std"
+import * as Y from "yjs"
+import {TransportAnchor} from "@/service/transport-sync/TransportAnchor"
+import {TransportChannel} from "@/service/transport-sync/TransportChannel"
+
+const Field = {Playing: "playing", Epoch: "epoch", AnchorPosition: "anchorPosition", Bpm: "bpm"} as const
+
+const readAnchor = (map: Y.Map<unknown>): Nullable<TransportAnchor> => {
+    const playing = map.get(Field.Playing)
+    const epoch = map.get(Field.Epoch)
+    const anchorPosition = map.get(Field.AnchorPosition)
+    const bpm = map.get(Field.Bpm)
+    if (typeof playing !== "boolean" || typeof epoch !== "number" || typeof anchorPosition !== "number" || typeof bpm !== "number") {return null}
+    return {playing, epoch, anchorPosition, bpm}
+}
+
+// Real phase-2 anchor channel: a `transport` Y.Map on the live room's Y.Doc, sibling to the
+// `boxes` map used for project sync but never entangled with it, so every room participant
+// (not just tabs on the same machine) shares the same anchor.
+export class TransportYjsChannel implements TransportChannel {
+    readonly #map: Y.Map<unknown>
+
+    constructor(doc: Y.Doc) {this.#map = doc.getMap("transport")}
+
+    publish(anchor: TransportAnchor): void {
+        this.#map.doc?.transact(() => {
+            this.#map.set(Field.Playing, anchor.playing)
+            this.#map.set(Field.Epoch, anchor.epoch)
+            this.#map.set(Field.AnchorPosition, anchor.anchorPosition)
+            this.#map.set(Field.Bpm, anchor.bpm)
+        })
+    }
+
+    subscribe(observer: Procedure<TransportAnchor>): Subscription {
+        const listener = (event: Y.YMapEvent<unknown>) => {
+            if (event.transaction.local) {return}
+            const anchor = readAnchor(this.#map)
+            if (isDefined(anchor)) {observer(anchor)}
+        }
+        this.#map.observe(listener)
+        return {terminate: () => this.#map.unobserve(listener)}
+    }
+
+    terminate(): void {}
+}

--- a/packages/app/studio/src/ui/RoomStatus.sass
+++ b/packages/app/studio/src/ui/RoomStatus.sass
@@ -33,5 +33,9 @@ component
       border-radius: 50%
       flex-shrink: 0
 
+    > .follow-icon
+      color: var(--color-blue)
+      font-size: 0.9em
+
     &.self
       color: var(--color-bright)

--- a/packages/app/studio/src/ui/RoomStatus.tsx
+++ b/packages/app/studio/src/ui/RoomStatus.tsx
@@ -39,11 +39,11 @@ export const RoomStatus = ({lifecycle, service}: Construct) => {
             const render = () => {
                 const states = awareness.awareness.getStates()
                 const localId = awareness.clientID
-                const users: Array<{ name: string, color: string, self: boolean }> = []
+                const users: Array<{ name: string, color: string, follow: boolean, self: boolean }> = []
                 states.forEach((state, clientId) => {
                     const user: Optional<AwarenessUserState> = state.user
                     if (isDefined(user)) {
-                        users.push({name: user.name, color: user.color, self: clientId === localId})
+                        users.push({name: user.name, color: user.color, follow: user.follow ?? false, self: clientId === localId})
                     }
                 })
                 users.sort((first, second) => first.self === second.self ? 0 : first.self ? -1 : 1)
@@ -53,6 +53,8 @@ export const RoomStatus = ({lifecycle, service}: Construct) => {
                     <div className={user.self ? "user self" : "user"}>
                         <span className="dot" style={{backgroundColor: user.color}}/>
                         <span>{user.name}</span>
+                        {user.follow && <Icon symbol={IconSymbol.Headphone} className="follow-icon"
+                                               onInit={element => element.setAttribute("title", "Following room playback")}/>}
                     </div>
                 )), trafficWatch)
             }

--- a/packages/app/studio/src/ui/components/Checkbox.tsx
+++ b/packages/app/studio/src/ui/components/Checkbox.tsx
@@ -1,4 +1,4 @@
-import {Lifecycle, MutableObservableValue, Procedure} from "@opendaw/lib-std"
+import {isDefined, Lifecycle, MutableObservableValue, ObservableValue, Procedure} from "@opendaw/lib-std"
 import {createElement, JsxValue} from "@opendaw/lib-jsx"
 import {Appearance, ButtonCheckboxRadio} from "@/ui/components/ButtonCheckboxRadio.tsx"
 import {Html} from "@opendaw/lib-dom"
@@ -10,9 +10,10 @@ type Construct = {
     className?: string
     appearance?: Appearance
     onInit?: Procedure<HTMLElement>
+    disabled?: ObservableValue<boolean>
 }
 
-export const Checkbox = ({lifecycle, model, style, className, appearance, onInit}: Construct, children: JsxValue) => {
+export const Checkbox = ({lifecycle, model, style, className, appearance, onInit, disabled}: Construct, children: JsxValue) => {
     const id = Html.nextID()
     const input: HTMLInputElement = (
         <input type="checkbox"
@@ -24,7 +25,7 @@ export const Checkbox = ({lifecycle, model, style, className, appearance, onInit
                checked={model.getValue()}/>
     )
     lifecycle.own(model.subscribe(model => input.checked = model.getValue()))
-    return (
+    const wrapper = (
         <ButtonCheckboxRadio lifecycle={lifecycle}
                              style={style}
                              className={className}
@@ -35,4 +36,8 @@ export const Checkbox = ({lifecycle, model, style, className, appearance, onInit
             <label htmlFor={id} style={{cursor: appearance?.cursor ?? "auto"}}>{children}</label>
         </ButtonCheckboxRadio>
     )
+    if (isDefined(disabled)) {
+        lifecycle.own(disabled.catchupAndSubscribe(owner => wrapper.classList.toggle("disabled", owner.getValue())))
+    }
+    return wrapper
 }

--- a/packages/app/studio/src/ui/header/TransportGroup.tsx
+++ b/packages/app/studio/src/ui/header/TransportGroup.tsx
@@ -3,7 +3,7 @@ import {Icon} from "@/ui/components/Icon.tsx"
 import {createElement} from "@opendaw/lib-jsx"
 import {StudioService} from "@/service/StudioService"
 import {Button} from "@/ui/components/Button.tsx"
-import {DefaultObservableValue, Lifecycle, Option, Terminator} from "@opendaw/lib-std"
+import {DefaultObservableValue, isDefined, Lifecycle, Option, Terminator} from "@opendaw/lib-std"
 import {Colors, IconSymbol} from "@opendaw/studio-enums"
 import {Checkbox} from "@/ui/components/Checkbox"
 import {Surface} from "@/ui/surface/Surface"
@@ -12,6 +12,12 @@ import {Html} from "@opendaw/lib-dom"
 import {ContextMenu, MenuItem, ProjectProfile} from "@opendaw/studio-core"
 import {GlobalShortcuts} from "@/ui/shortcuts/GlobalShortcuts"
 import {ShortcutTooltip} from "@/ui/shortcuts/ShortcutTooltip"
+import {RejoinGrid} from "@/service/transport-sync/TransportSyncService"
+
+const RejoinGridLabels: ReadonlyArray<{ grid: RejoinGrid, label: string }> = [
+    {grid: "bar", label: "Bar"},
+    {grid: "beat", label: "Beat"}
+]
 
 const className = Html.adoptStyleSheet(css, "TransportGroup")
 
@@ -24,6 +30,8 @@ export const TransportGroup = ({lifecycle, service}: Construct) => {
     const {engine, projectProfileService} = service
     const {preferences: {settings: {playback}}} = engine
     const loop = new DefaultObservableValue(false)
+    const notInRoom = new DefaultObservableValue(true)
+    lifecycle.own(service.roomAwareness.catchupAndSubscribe(owner => notInRoom.setValue(!isDefined(owner.getValue()))))
     const recordButton: HTMLElement = (
         <Button lifecycle={lifecycle}
                 appearance={{
@@ -51,10 +59,24 @@ export const TransportGroup = ({lifecycle, service}: Construct) => {
                 onClick={() => {
                     if (engine.isPlaying.getValue()) {
                         engine.stop()
+                        service.transportSync.publishLocal(false)
                     } else {
                         engine.play()
+                        service.transportSync.publishLocal(true)
                     }
                 }}><Icon symbol={IconSymbol.Play}/></Button>
+    )
+    const followCheckbox: HTMLElement = (
+        <Checkbox lifecycle={lifecycle}
+                  model={service.transportSync.follow}
+                  disabled={notInRoom}
+                  appearance={{
+                      color: Colors.shadow,
+                      activeColor: Colors.blue,
+                      tooltip: "Follow Room Playback"
+                  }}>
+            <Icon symbol={IconSymbol.Headphone}/>
+        </Checkbox>
     )
     const loopLifecycle = lifecycle.own(new Terminator())
     const countInLifecycle = lifecycle.own(new Terminator())
@@ -82,6 +104,14 @@ export const TransportGroup = ({lifecycle, service}: Construct) => {
                     checked: playback.pauseOnLoopDisabled
                 }).setTriggerProcedure(() => playback.pauseOnLoopDisabled = !playback.pauseOnLoopDisabled)
             )),
+        ContextMenu.subscribe(followCheckbox, collector => collector
+            .addItems(
+                MenuItem.header({label: "Rejoin Quantization", icon: IconSymbol.Headphone, color: Colors.blue}),
+                ...RejoinGridLabels.map(({grid, label}) => MenuItem.default({
+                    label,
+                    checked: service.transportSync.rejoinGrid.getValue() === grid
+                }).setTriggerProcedure(() => service.transportSync.rejoinGrid.setValue(grid)))
+            )),
         projectProfileService.catchupAndSubscribe((optProfile: Option<ProjectProfile>) => {
             loopLifecycle.terminate()
             optProfile.match({
@@ -104,7 +134,10 @@ export const TransportGroup = ({lifecycle, service}: Construct) => {
             {recordButton}
             {playButton}
             <Button lifecycle={lifecycle}
-                    onClick={() => {engine.stop(true)}}
+                    onClick={() => {
+                        engine.stop(true)
+                        service.transportSync.publishLocal(false)
+                    }}
                     appearance={{
                         color: Colors.shadow,
                         activeColor: Colors.bright,
@@ -121,6 +154,7 @@ export const TransportGroup = ({lifecycle, service}: Construct) => {
                       }}>
                 <Icon symbol={IconSymbol.Loop}/>
             </Checkbox>
+            {followCheckbox}
         </div>
     )
 }

--- a/plans/transport-sync.md
+++ b/plans/transport-sync.md
@@ -1,0 +1,138 @@
+# Transport Sync: Shared Listening in Live Rooms
+
+## Goal
+
+Give Live Room participants the sensation of listening together — same section, roughly the
+same position, roughly in phase — without attempting sample-accurate synchronized playback.
+Model: Strudel/Flok, not Ableton Link. No continuous clock negotiation; every client
+independently recomputes its own position from a shared anchor.
+
+---
+
+## TransportAnchor
+
+The shared state is a small plain object, deliberately not a running clock:
+
+```typescript
+type TransportAnchor = {
+    playing: boolean
+    epoch: number          // Date.now() when this anchor was set
+    anchorPosition: ppqn   // timeline position at that instant
+    bpm: bpm
+}
+```
+
+Every client derives its own position fresh from these four numbers instead of running a
+local counter:
+
+```typescript
+currentPosition = anchorPosition + (Date.now() - epoch) * (bpm / 60)
+```
+
+`TransportAnchor.recompute(anchor, now)` implements this.
+
+## TransportChannel
+
+`TransportChannel` is the transport-agnostic interface (`publish` / `subscribe`) the sync
+service talks to. Two implementations:
+
+- **`TransportBroadcastChannel`** — same-origin `BroadcastChannel`, zero networking. Used to
+  validate the recompute formula and quantized-rejoin behavior with two local tabs before any
+  room/Yjs involvement.
+- **`TransportYjsChannel`** — wraps a `transport` `Y.Map` kept as a sibling of the existing
+  `boxes` map on the room's `Y.Doc`, never entangled with the structural project-edit CRDT.
+  This is the real live-room path; `StudioLiveRoomConnect` attaches it on room join.
+
+## TransportSyncService
+
+Owned by `StudioService` (`service.transportSync`), outlives any single room. `attach(channel)`
+swaps in a channel when one becomes available and returns a `Terminable` to detach.
+
+```typescript
+class TransportSyncService implements Terminable {
+    get follow(): DefaultObservableValue<boolean>
+    get rejoinGrid(): DefaultObservableValue<RejoinGrid>   // "bar" | "beat"
+
+    attach(channel: TransportChannel): Terminable
+    publishLocal(playing: boolean): void
+}
+```
+
+### Ownership: last-action-wins
+
+Whoever presses play/stop — or seeks — broadcasts a fresh anchor via `publishLocal`; it simply
+overwrites the previous one. No leader election. Hooked from `StudioShortcutManager` (play/stop
+shortcuts) and `TransportGroup` (play/stop/loop buttons).
+
+### Opt-in per client
+
+A "follow room playback" toggle (headphone icon) in `TransportGroup`, disabled while outside a
+room. Nobody's transport gets hijacked without asking. Following is itself broadcast — see
+Room Awareness below — so everyone can see who's listening along.
+
+### Quantized rejoin
+
+On receiving a new/changed anchor while `follow` is on, don't hard-cut: round to the next bar
+or beat boundary (`rejoinGrid`, configurable via right-click on the follow toggle) before
+applying, so a late update sounds like a rejoin, not a stutter. If playback is currently
+stopped, or drift is small, it snaps immediately instead of waiting for a grid line.
+
+### Tolerance, not precision
+
+A 500ms interval re-checks drift against the latest anchor while playing and following; only
+schedules a rejoin if drift exceeds ~175ms. No continuous phase correction.
+
+### Streaming local seeks
+
+`publishLocal` alone only covers play/stop. A local seek mid-playback (dragging the timeline
+ruler, jump-to-grid, piano-roll click) also needs to re-anchor the stream, otherwise followers
+keep extrapolating from the pre-seek position until the next stop/play.
+
+`engine.position` ticks continuously during ordinary playback (every engine state message from
+the audio thread), not just on seeks, so the service can't simply republish on every position
+change — that would flood the channel. Instead it tracks where playback should naturally be
+since the last tick and only republishes when the actual position diverges from that
+expectation by more than the drift tolerance — i.e. a genuine discontinuity. Broadcasts are
+coalesced to once per animation frame (`deferNextFrame`, the same pattern `RoomAwareness` uses
+for its own broadcasts), so a click-drag seek doesn't spam the channel either.
+
+This local-seek detection is guarded against the service's own remote-driven `setPosition`
+calls (a follower snapping/rejoining to someone else's anchor) via an internal
+`#applyingRemote` flag — otherwise following would immediately echo back as a new "local seek."
+
+---
+
+## Room Awareness: who's following
+
+`RoomAwareness` gained a `follow: boolean` field alongside the existing `name` / `color` /
+`panel`, broadcast the same way (batched via `deferNextFrame` into the Yjs awareness protocol).
+`StudioLiveRoomConnect` keeps it in sync with `service.transportSync.follow` for the duration
+of the room session. `RoomStatus` renders a small headphone icon next to any user whose
+`follow` flag is set.
+
+---
+
+## Where this lives
+
+- `packages/app/studio/src/service/transport-sync/` — `TransportAnchor`, `TransportChannel`,
+  `TransportBroadcastChannel`, `TransportYjsChannel`, `TransportSyncService`
+- `packages/app/studio/src/service/StudioService.ts` — owns `transportSync`
+- `packages/app/studio/src/service/StudioLiveRoomConnect.ts` — attaches the Yjs channel on join
+- `packages/app/studio/src/service/StudioShortcutManager.ts` — play/stop shortcuts publish
+- `packages/app/studio/src/service/RoomAwareness.ts`, `src/ui/RoomStatus.tsx` — follow indicator
+- `packages/app/studio/src/ui/header/TransportGroup.tsx` — follow toggle, rejoin-grid menu
+- `packages/app/studio/src/ui/components/Checkbox.tsx` — gained an optional `disabled` prop,
+  used to disable the follow toggle outside a room
+
+## Validated
+
+Two tabs, same room, `follow` enabled on one: play/stop, mid-playback seeking (ruler drag), and
+the bar/beat rejoin-quantization menu all keep the follower in sync. `tsc --noEmit` clean at
+every commit in the implementation series.
+
+## Open questions
+
+- Whether bar- or beat-level quantization feels better is genre/tempo dependent — currently a
+  per-client menu choice rather than a fixed default; worth revisiting with more real usage.
+- Drift tolerance (175ms) is a starting guess validated informally on localhost; untested over
+  a real high-latency WAN link between distant participants.


### PR DESCRIPTION
Adds opt-in synced playback for Live Room participants — same section, roughly the same position, roughly in phase — without attempting sample-accurate sync.

Closes #325 

> Draft for early feedback — happy to split further, rename, or rework anything to fit project conventions. Design doc at `plans/transport-sync.md` (mirrors the existing `plans/room-awareness.md` / `plans/live-room-selections.md` format) documents the full design.

## Problem

Today, Live Room transport state is entirely local. Pressing play in one tab has no effect on anyone else in the room, so there's no way to say "let's listen from the top" together — everyone has to manually eyeball a countdown or voice-chat a "3, 2, 1, go."

## Design

Modeled on Strudel/Flok-style periodic-anchor recompute, not Ableton Link-style continuous clock negotiation — a much better fit for "felt sync" over a real WAN connection than for sample accuracy:

- A small shared anchor `{ playing, epoch, anchorPosition, bpm }` lives in its own `Y.Map ("transport")`, kept apart from the existing boxes map so ephemeral playback state doesn't get entangled with the structural project-edit CRDT.
- Every client independently recomputes position from the anchor `(anchorPosition + (Date.now() - epoch) * (bpm / 60))` rather than trusting a running counter.
- Last-action-wins — whoever presses play/stop, or seeks, broadcasts a fresh anchor. No leader election.
- Opt-in per client — a "follow room playback" toggle (headphone icon in the transport bar), off while editing solo.
- Quantized rejoin — on a changed anchor, wait for the next bar/beat boundary (configurable via right-click menu) before snapping, so a late update sounds like a rejoin, not a stutter.
- Tolerance, not precision — periodic drift check, nudge only past ~175ms, no continuous phase correction.

## Implementation

Split into small, incremental commits, each independently buildable/typechecked, per the contributing guidelines:

1. `transport-sync/` module — `TransportAnchor`, `TransportChannel` interface, `TransportBroadcastChannel` (same-machine prototyping), `TransportYjsChannel` (the real room path), `TransportSyncService`
2. Wire the service into `StudioService`
3. Checkbox gets an optional disabled prop (needed for the follow toggle when outside a room)
4. `RoomAwareness/RoomStatus` show a headphone icon next to whoever's following
5. Local play/stop shortcuts publish to the anchor
6. `StudioLiveRoomConnect` attaches the Yjs channel on room join
7. Transport bar gets the follow toggle + rejoin-quantization context menu
8. Fix: local seeks _during_ playback (ruler drag, jump-to-grid) now also stream — initially only play/stop published, so mid-playback seeks were invisible to followers until the next stop/play. Detecting a genuine seek (vs. the ~60/sec position ticks that happen during ordinary playback) required comparing actual vs. expected position since the last tick rather than diffing on every change.
9. `plans/transport-sync.md` — design doc, matching the repo's existing plans/ convention

## Verification

- `tsc --noEmit` clean at every commit in the series (app stays buildable throughout)
- Manual: two browser tabs, same room, follow enabled on one — play/stop, mid-playback seeking (ruler drag), and the bar/beat rejoin-quantization menu all verified to keep the follower in sync
- Also tested across two separate computers on different networks (real WAN, not just localhost) — sync held up well, same section and roughly in phase as intended
- No changes to the project-document Yjs sync path (`boxes` map) — transport lives in its own `Y.Map`, isolated from structural edits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added synchronized playback for Live Room participants.
  * Added an optional follow mode with bar- or beat-aligned rejoining.
  * Playback, stopping, seeking, and drift correction now synchronize across connected sessions.
  * Added follow indicators to room participant status.
  * Added a disabled state for checkboxes when the related action is unavailable.

* **Documentation**
  * Added documentation describing transport synchronization behavior and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->