### PR TITLE
warp to the sample's own bpm when converting not-stretched to a stretched play-mode

### DIFF
--- a/packages/studio/core/src/project/audio/AudioContentModifier.ts
+++ b/packages/studio/core/src/project/audio/AudioContentModifier.ts
@@ -1,6 +1,6 @@
-import {EmptyExec, Exec, isDefined, isInstanceOf, isNotNull, Option, RuntimeNotifier, UUID} from "@opendaw/lib-std"
+import {EmptyExec, Exec, isDefined, isInstanceOf, isNotNull, Option, quantizeRound, RuntimeNotifier, UUID} from "@opendaw/lib-std"
 import {BoxGraph} from "@opendaw/lib-box"
-import {EventCollection, ppqn, seconds, TimeBase} from "@opendaw/lib-dsp"
+import {EventCollection, ppqn, PPQN, seconds, TimeBase} from "@opendaw/lib-dsp"
 import {
     AudioPitchStretchBox,
     AudioRegionBox,
@@ -13,6 +13,7 @@ import {AudioContentBoxAdapter, AudioPlayMode, AudioRegionBoxAdapter, WarpMarker
 import {AudioContentHelpers} from "./AudioContentHelpers"
 import {Workers} from "../../Workers"
 import {Pointers} from "@opendaw/studio-enums"
+import {SampleStorage} from "../../samples/SampleStorage"
 
 export namespace AudioContentModifier {
     export const toNotStretched = async (adapters: ReadonlyArray<AudioContentBoxAdapter>): Promise<Exec> => {
@@ -39,12 +40,13 @@ export namespace AudioContentModifier {
     export const toPitchStretch = async (adapters: ReadonlyArray<AudioContentBoxAdapter>): Promise<Exec> => {
         const audioAdapters = adapters.filter(adapter => adapter.asPlayModePitchStretch.isEmpty())
         if (audioAdapters.length === 0) {return EmptyExec}
-        return () => audioAdapters.forEach((adapter) => {
+        const tasks = await Promise.all(audioAdapters.map(async adapter => ({adapter, bpm: await readSampleBpm(adapter)})))
+        return () => tasks.forEach(({adapter, bpm}) => {
             const optPrev: Option<AudioPlayMode> = adapter.observableOptPlayMode.map(mode => mode)
             const boxGraph = adapter.box.graph
             const pitchStretch = AudioPitchStretchBox.create(boxGraph, UUID.generate())
             adapter.box.playMode.refer(pitchStretch)
-            adoptWarpMarkers(optPrev, pitchStretch, boxGraph, adapter)
+            adoptWarpMarkers(optPrev, pitchStretch, boxGraph, adapter, bpm)
             switchTimeBaseToMusical(adapter)
         })
     }
@@ -52,12 +54,13 @@ export namespace AudioContentModifier {
     export const toSignalsmith = async (adapters: ReadonlyArray<AudioContentBoxAdapter>): Promise<Exec> => {
         const audioAdapters = adapters.filter(adapter => adapter.asPlayModeSignalsmith.isEmpty())
         if (audioAdapters.length === 0) {return EmptyExec}
-        return () => audioAdapters.forEach((adapter) => {
+        const tasks = await Promise.all(audioAdapters.map(async adapter => ({adapter, bpm: await readSampleBpm(adapter)})))
+        return () => tasks.forEach(({adapter, bpm}) => {
             const optPrev: Option<AudioPlayMode> = adapter.observableOptPlayMode.map(mode => mode)
             const boxGraph = adapter.box.graph
             const signalsmith = AudioSignalsmithBox.create(boxGraph, UUID.generate())
             adapter.box.playMode.refer(signalsmith)
-            adoptWarpMarkers(optPrev, signalsmith, boxGraph, adapter)
+            adoptWarpMarkers(optPrev, signalsmith, boxGraph, adapter, bpm)
             switchTimeBaseToMusical(adapter)
         })
     }
@@ -67,21 +70,23 @@ export namespace AudioContentModifier {
         if (audioAdapters.length === 0) {return EmptyExec}
         const handler = RuntimeNotifier.progress({headline: "Detecting Transients..."})
         const tasks = await Promise.all(audioAdapters.map(async adapter => {
+            const bpm = await readSampleBpm(adapter)
             if (adapter.file.transients.length() === 0) {
                 return {
                     adapter,
+                    bpm,
                     transients: await Workers.Transients.detect(await adapter.file.audioData)
                 }
             }
-            return {adapter}
+            return {adapter, bpm}
         }))
         handler.terminate()
-        return () => tasks.forEach(({adapter, transients}) => {
+        return () => tasks.forEach(({adapter, bpm, transients}) => {
             const optPrev: Option<AudioPlayMode> = adapter.observableOptPlayMode.map(mode => mode)
             const boxGraph = adapter.box.graph
             const timeStretch = AudioTimeStretchBox.create(boxGraph, UUID.generate())
             adapter.box.playMode.refer(timeStretch)
-            adoptWarpMarkers(optPrev, timeStretch, boxGraph, adapter)
+            adoptWarpMarkers(optPrev, timeStretch, boxGraph, adapter, bpm)
             if (isDefined(transients) && adapter.file.transients.length() === 0) {
                 const markersField = adapter.file.box.transientMarkers
                 transients.forEach(position => TransientMarkerBox.create(boxGraph, UUID.generate(), box => {
@@ -119,15 +124,27 @@ export namespace AudioContentModifier {
         return {ppqn: adapter.duration, seconds: adapter.box.duration.getValue()}
     }
 
+    const warpedExtent = (adapter: AudioContentBoxAdapter, bpm: number): {ppqn: number, seconds: number} => {
+        const {seconds} = sampleExtent(adapter)
+        const pulses = PPQN.secondsToPulses(seconds, bpm)
+        return {ppqn: pulses >= PPQN.SemiQuaver ? quantizeRound(pulses, PPQN.SemiQuaver) : pulses, seconds}
+    }
+
+    const readSampleBpm = async (adapter: AudioContentBoxAdapter): Promise<number> =>
+        (await Option.async(SampleStorage.get().loadMeta(adapter.file.uuid))).mapOr(meta => meta.bpm, 0)
+
     // Move the warp markers of the previous play-mode (if any) onto the new play-mode box, so switching between
     // Pitch / Grain / Signalsmith preserves the user's warp edits; delete the old box if nothing else points at
-    // it (else clone the markers). With no previous stretch (was NoWarp), seed default markers instead.
+    // it (else clone the markers). With no previous stretch (was NoWarp), seed default markers warped to the
+    // sample's own bpm as stored in its metadata; the project-tempo-relative extent is only a defensive
+    // fallback for callers that never wrote a meaningful bpm.
     const adoptWarpMarkers = (optPrev: Option<AudioPlayMode>,
                               newBox: AudioPitchStretchBox | AudioTimeStretchBox | AudioSignalsmithBox,
                               boxGraph: BoxGraph,
-                              adapter: AudioContentBoxAdapter): void => optPrev.match({
+                              adapter: AudioContentBoxAdapter,
+                              bpm: number): void => optPrev.match({
         none: () => {
-            const {ppqn, seconds} = sampleExtent(adapter)
+            const {ppqn, seconds} = bpm > 0 ? warpedExtent(adapter, bpm) : sampleExtent(adapter)
             AudioContentHelpers.addDefaultWarpMarkers(boxGraph, newBox, ppqn, seconds)
         },
         some: from => {

--- a/packages/studio/core/src/project/audio/AudioContentModifier.ts
+++ b/packages/studio/core/src/project/audio/AudioContentModifier.ts
@@ -46,8 +46,7 @@ export namespace AudioContentModifier {
             const boxGraph = adapter.box.graph
             const pitchStretch = AudioPitchStretchBox.create(boxGraph, UUID.generate())
             adapter.box.playMode.refer(pitchStretch)
-            adoptWarpMarkers(optPrev, pitchStretch, boxGraph, adapter, bpm)
-            switchTimeBaseToMusical(adapter)
+            switchTimeBaseToMusical(adapter, adoptWarpMarkers(optPrev, pitchStretch, boxGraph, adapter, bpm))
         })
     }
 
@@ -60,8 +59,7 @@ export namespace AudioContentModifier {
             const boxGraph = adapter.box.graph
             const signalsmith = AudioSignalsmithBox.create(boxGraph, UUID.generate())
             adapter.box.playMode.refer(signalsmith)
-            adoptWarpMarkers(optPrev, signalsmith, boxGraph, adapter, bpm)
-            switchTimeBaseToMusical(adapter)
+            switchTimeBaseToMusical(adapter, adoptWarpMarkers(optPrev, signalsmith, boxGraph, adapter, bpm))
         })
     }
 
@@ -86,7 +84,7 @@ export namespace AudioContentModifier {
             const boxGraph = adapter.box.graph
             const timeStretch = AudioTimeStretchBox.create(boxGraph, UUID.generate())
             adapter.box.playMode.refer(timeStretch)
-            adoptWarpMarkers(optPrev, timeStretch, boxGraph, adapter, bpm)
+            const optWarped = adoptWarpMarkers(optPrev, timeStretch, boxGraph, adapter, bpm)
             if (isDefined(transients) && adapter.file.transients.length() === 0) {
                 const markersField = adapter.file.box.transientMarkers
                 transients.forEach(position => TransientMarkerBox.create(boxGraph, UUID.generate(), box => {
@@ -94,7 +92,7 @@ export namespace AudioContentModifier {
                     box.position.setValue(position)
                 }))
             }
-            switchTimeBaseToMusical(adapter)
+            switchTimeBaseToMusical(adapter, optWarped)
         })
     }
 
@@ -137,15 +135,17 @@ export namespace AudioContentModifier {
     // Pitch / Grain / Signalsmith preserves the user's warp edits; delete the old box if nothing else points at
     // it (else clone the markers). With no previous stretch (was NoWarp), seed default markers warped to the
     // sample's own bpm as stored in its metadata; the project-tempo-relative extent is only a defensive
-    // fallback for callers that never wrote a meaningful bpm.
+    // fallback for callers that never wrote a meaningful bpm. Returns the bpm-warped marker extent when one
+    // was seeded, so the timebase switch can size the region from it instead of the project-tempo conversion.
     const adoptWarpMarkers = (optPrev: Option<AudioPlayMode>,
                               newBox: AudioPitchStretchBox | AudioTimeStretchBox | AudioSignalsmithBox,
                               boxGraph: BoxGraph,
                               adapter: AudioContentBoxAdapter,
-                              bpm: number): void => optPrev.match({
+                              bpm: number): Option<ppqn> => optPrev.match({
         none: () => {
             const {ppqn, seconds} = bpm > 0 ? warpedExtent(adapter, bpm) : sampleExtent(adapter)
             AudioContentHelpers.addDefaultWarpMarkers(boxGraph, newBox, ppqn, seconds)
+            return bpm > 0 ? Option.wrap(ppqn) : Option.None
         },
         some: from => {
             const to = newBox.warpMarkers
@@ -160,6 +160,7 @@ export namespace AudioContentModifier {
                 from.warpMarkers.asArray().forEach(({box: {owner}}) => owner.refer(to))
                 from.box.delete()
             }
+            return Option.None
         }
     })
 
@@ -175,16 +176,32 @@ export namespace AudioContentModifier {
         })
     }
 
-    const switchTimeBaseToMusical = (adapter: AudioContentBoxAdapter): void => {
+    const switchTimeBaseToMusical = (adapter: AudioContentBoxAdapter, optWarpedDuration: Option<ppqn>): void => {
         const {timeBase} = adapter
         if (timeBase === TimeBase.Musical) {return}
         const {box} = adapter
-        box.duration.setValue(adapter.duration)
-        if (isInstanceOf(adapter, AudioRegionBoxAdapter)) {
-            const {box: {loopDuration, loopOffset}} = adapter
-            loopOffset.setValue(adapter.loopOffset)
-            loopDuration.setValue(adapter.loopDuration)
-        }
+        optWarpedDuration.match({
+            none: () => {
+                box.duration.setValue(adapter.duration)
+                if (isInstanceOf(adapter, AudioRegionBoxAdapter)) {
+                    const {box: {loopDuration, loopOffset}} = adapter
+                    loopOffset.setValue(adapter.loopOffset)
+                    loopDuration.setValue(adapter.loopDuration)
+                }
+            },
+            some: warpedPpqn => {
+                if (isInstanceOf(adapter, AudioRegionBoxAdapter)) {
+                    const {box: {loopDuration, loopOffset}} = adapter
+                    const loopSeconds = loopDuration.getValue()
+                    const scale = loopSeconds > 0 ? warpedPpqn / loopSeconds : 0
+                    box.duration.setValue(box.duration.getValue() * scale)
+                    loopOffset.setValue(loopOffset.getValue() * scale)
+                    loopDuration.setValue(warpedPpqn)
+                } else {
+                    box.duration.setValue(warpedPpqn)
+                }
+            }
+        })
         box.timeBase.setValue(TimeBase.Musical)
     }
 }


### PR DESCRIPTION
Fixes #332.

## Problem

Converting an audio region/clip from not-stretched to any stretched play-mode (`toSignalsmith` / `toPitchStretch` / `toTimeStretch`) seeded the default warp markers from the region's current project-tempo-relative extent (`sampleExtent`), never consulting the sample's own bpm stored in `SampleMetaData`. The result is a silent 1× "stretch" whenever the sample's bpm differs from the project tempo. See #332 for full reproduction and captured numbers.

## Fix

Two parts, both in `packages/studio/core/src/project/audio/AudioContentModifier.ts`:

**1. Seed warp markers from the sample's own bpm**

- New `readSampleBpm`: reads `SampleMetaData.bpm` via `SampleStorage.get().loadMeta(adapter.file.uuid)`; resolves to `0` if the meta can't be loaded (via `Option.async`, so the conversion never throws).
- New `warpedExtent`: computes the marker extent as `PPQN.secondsToPulses(seconds, bpm)`, quantized to `PPQN.SemiQuaver` — the same math `AudioContentFactory.createRegionWithWarpMarkers` already uses at creation time.
- `adoptWarpMarkers`'s `none` branch uses `warpedExtent` when `bpm > 0` and falls back to the previous `sampleExtent` behavior when the stored bpm is `0`/unknown (mirroring `AudioContentFactory.calculateDuration`'s `bpm === 0` branch).
- `toPitchStretch` and `toSignalsmith` now follow the same async-prep-then-sync-exec shape `toTimeStretch` already uses for transient detection. Their signatures were already `Promise<Exec>` and callers already `await` them, so no breaking change.

**2. Size the region boundary from the warped extent**

Manual testing surfaced a second half: with part 1 alone the *content* warped correctly but the region boundary stayed at the un-warped length, because `switchTimeBaseToMusical` writes `duration`/`loopDuration` from `adapter.duration` — a project-tempo conversion of the current seconds length. `adoptWarpMarkers` now returns the bpm-warped extent it seeded (`Option<ppqn>`), and `switchTimeBaseToMusical` sizes the region from it: `loopDuration = warpedPpqn`, with `duration` and `loopOffset` scaled relative to the loop length so looped regions keep their loop count. The fallback and marker carry-over paths keep the previous behavior.

## Verified manually

- 140 bpm 8-bar sample at project tempo 100: not-stretched → Time-Stretch lands at exactly 30720 ppqn (8 bars), markers `(0|0s) (30720|13.714s)` — previously stayed at the un-warped 21943 ppqn.
- Round trip at matching tempo (not-stretched → stretched → not-stretched → stretched) is stable at 30720.
- A 30s sample with stored bpm 128 converts to 61440 ppqn (16 bars) as expected.

Untouched, per the acceptance criteria in #332: the `some` branch (stretched → stretched marker carry-over) and `toNotStretched`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio play-mode conversions by using the source sample’s BPM when creating warp markers.
  * Enhanced time-stretch detection to preserve BPM information alongside transient data.
  * Adjusted region and loop durations more accurately when converting musical time-based audio.
  * Added fallback handling for missing or zero BPM values to maintain previous behavior.
  * Improved timing consistency for pitch-stretch, Signalsmith, and time-stretch conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->