### PR TITLE
Fix clip view bounds

### DIFF
--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/TracksManager.ts
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/TracksManager.ts
@@ -121,8 +121,6 @@ export class TracksManager implements Terminable {
     readonly #terminator: Terminator
     readonly #audioUnits: SortedSet<UUID.Bytes, { uuid: UUID.Bytes, unitTracks: HTMLElement, lifecycle: Terminable }>
     readonly #tracks: SortedSet<UUID.Bytes, TrackContext>
-    readonly #maxClipsIndex: DefaultObservableValue<int>
-
     #currentClipModifier: Option<ClipModifier> = Option.None
     #currentRegionModifier: Option<RegionModifier> = Option.None
     #orderedByIndex: Option<ReadonlyArray<TrackContext>> = Option.None
@@ -135,7 +133,6 @@ export class TracksManager implements Terminable {
         this.#terminator = new Terminator()
         this.#audioUnits = UUID.newSet(({uuid}) => uuid)
         this.#tracks = UUID.newSet(({trackBoxAdapter: {uuid}}) => uuid)
-        this.#maxClipsIndex = this.#terminator.own(new DefaultObservableValue(8))
         this.#terminator.own(this.#subscribe())
     }
 
@@ -191,7 +188,6 @@ export class TracksManager implements Terminable {
 
     get currentClipModifier(): Option<ClipModifier> {return this.#currentClipModifier}
     get currentRegionModifier(): Option<RegionModifier> {return this.#currentRegionModifier}
-    get maxClipsIndex(): DefaultObservableValue<number> {return this.#maxClipsIndex}
     get service(): StudioService {return this.#service}
 
     localToIndex(position: number): int {

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipMoveModifier.ts
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipMoveModifier.ts
@@ -5,6 +5,11 @@ import {TracksManager} from "@/ui/timeline/tracks/audio-unit/TracksManager.ts"
 import {ClipModifyStrategy} from "@/ui/timeline/tracks/audio-unit/clips/ClipModifyStrategy.ts"
 import {Dragging} from "@opendaw/lib-dom"
 import {Project} from "@opendaw/studio-core"
+import {
+    clampClipMoveDelta,
+    MaxClipCount,
+    movedClipCount
+} from "@/ui/timeline/tracks/audio-unit/clips/constants.ts"
 
 class UnselectedModifyStrategy implements ClipModifyStrategy {
     readonly #tool: ClipMoveModifier
@@ -50,6 +55,7 @@ export class ClipMoveModifier implements ClipModifier {
     readonly #yAxis: ValueAxis
     readonly #pointerClipIndex: int
     readonly #pointerTrackIndex: int
+    readonly #initialClipCount: int
 
     readonly #selectedModifyStrategy: ClipModifyStrategy
     readonly #unselectedModifyStrategy: ClipModifyStrategy
@@ -67,6 +73,7 @@ export class ClipMoveModifier implements ClipModifier {
         this.#yAxis = yAxis
         this.#pointerClipIndex = pointerClipIndex
         this.#pointerTrackIndex = pointerTrackIndex
+        this.#initialClipCount = manager.service.timeline.clips.count.getValue()
 
         this.#selectedModifyStrategy = new SelectedModifyStrategy(this)
         this.#unselectedModifyStrategy = new UnselectedModifyStrategy(this)
@@ -86,10 +93,12 @@ export class ClipMoveModifier implements ClipModifier {
         const trackIndex: int = this.#yAxis.axisToValue(clientY)
         const maxTrackIndex = this.#manager.numTracks() - 1
         const adapters = this.#selection.selected()
-        const clipDelta = adapters.reduce((delta, adapter) => {
-            const listIndex = adapter.indexField.getValue()
-            return clamp(delta, -listIndex, this.#manager.maxClipsIndex.getValue() + 1)
-        }, clipIndex - this.#pointerClipIndex)
+        const clipIndices = adapters.map(adapter => adapter.indexField.getValue())
+        const maxClipCount = Math.max(MaxClipCount, this.#initialClipCount)
+        const clipDelta = clampClipMoveDelta(
+            clipIndex - this.#pointerClipIndex, clipIndices, maxClipCount)
+        this.#manager.service.timeline.clips.count.setValue(
+            movedClipCount(this.#initialClipCount, clipIndices, clipDelta))
         const trackDelta = adapters.reduce((delta, adapter) => {
             const listIndex = adapter.trackBoxAdapter.unwrap("trackBoxAdapter").listIndex
             return clamp(delta, -listIndex, maxTrackIndex - listIndex)
@@ -187,7 +196,10 @@ export class ClipMoveModifier implements ClipModifier {
         })
     }
 
-    cancel(): void {this.#dispatchChange()}
+    cancel(): void {
+        this.#manager.service.timeline.clips.count.setValue(this.#initialClipCount)
+        this.#dispatchChange()
+    }
 
     #dispatchChange(): void {
         this.#dispatchSameTrackChange()

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipViewBounds.test.ts
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipViewBounds.test.ts
@@ -1,0 +1,27 @@
+import {describe, expect, it} from "vitest"
+import {
+    clampClipCount,
+    clampClipMoveDelta,
+    MaxClipCount,
+    movedClipCount
+} from "@/ui/timeline/tracks/audio-unit/clips/constants.ts"
+
+describe("clip view bounds (185)", () => {
+    it("keeps every moved clip inside the last available column", () => {
+        expect(clampClipMoveDelta(20, [0], MaxClipCount)).toBe(8)
+        expect(clampClipMoveDelta(4, [1, 7], MaxClipCount)).toBe(1)
+        expect(clampClipMoveDelta(-20, [2, 5], MaxClipCount)).toBe(-2)
+    })
+
+    it("grows the visible clip count to include a moved clip", () => {
+        expect(movedClipCount(3, [0], 8)).toBe(9)
+        expect(movedClipCount(3, [1, 2], 2)).toBe(5)
+        expect(movedClipCount(3, [4], -2)).toBe(3)
+    })
+
+    it("caps resize while preserving every occupied column", () => {
+        expect(clampClipCount(20, 1)).toBe(MaxClipCount)
+        expect(clampClipCount(2, 5)).toBe(5)
+        expect(clampClipCount(20, 12)).toBe(12)
+    })
+})

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipsHeader.tsx
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipsHeader.tsx
@@ -6,6 +6,7 @@ import {Icon} from "@/ui/components/Icon.tsx"
 import {IconSymbol} from "@opendaw/studio-enums"
 import {deferNextFrame, Dragging, Events, Html} from "@opendaw/lib-dom"
 import {TextTooltip} from "@/ui/surface/TextTooltip"
+import {clampClipCount} from "@/ui/timeline/tracks/audio-unit/clips/constants.ts"
 
 const className = Html.adoptStyleSheet(css, "ClipsHeader")
 
@@ -28,6 +29,11 @@ export const ClipsHeader = ({lifecycle, service}: Construct) => {
     const {engine, rootBoxAdapter} = project
     const clips = timeline.clips
     const cells: Array<Cell> = []
+    const minimumClipCount = () => rootBoxAdapter.audioUnits.adapters()
+        .reduce((unitCount, unit) => unit.tracks.values()
+            .reduce((trackCount, track) => track.clips.collection.adapters()
+                .reduce((clipCount, clip) => Math.max(clipCount, clip.indexField.getValue() + 1), trackCount),
+            unitCount), 1)
     const {request: requestRebuild} = deferNextFrame(() => {
         const count = clips.count.getValue()
         for (let index = cells.length; index < count; index++) {
@@ -93,12 +99,17 @@ export const ClipsHeader = ({lifecycle, service}: Construct) => {
         }),
         Dragging.attach(resizer, ({clientX: beginPosition}) => {
             const beginValue = clips.count.getValue()
+            const minimumCount = minimumClipCount()
             const cellSize = parseInt(window.getComputedStyle(element).getPropertyValue("--clips-width")) + 1 // gaps
             return Option.wrap({
                 update: ({clientX: newPosition}) => {
                     const newValue = Math.max(0, beginValue + Math.round((newPosition - beginPosition) / cellSize))
-                    clips.count.setValue(Math.max(1, newValue))
-                    clips.visible.setValue(newValue > 0)
+                    if (newValue === 0) {
+                        clips.visible.setValue(false)
+                        return
+                    }
+                    clips.count.setValue(clampClipCount(newValue, minimumCount))
+                    clips.visible.setValue(true)
                 },
                 cancel: () => {}
             } satisfies Dragging.Process)

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipsHeader.tsx
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipsHeader.tsx
@@ -98,12 +98,13 @@ export const ClipsHeader = ({lifecycle, service}: Construct) => {
             }
         }),
         Dragging.attach(resizer, ({clientX: beginPosition}) => {
-            const beginValue = clips.count.getValue()
+            const beginCount = clips.count.getValue()
+            const beginVisible = clips.visible.getValue()
             const minimumCount = minimumClipCount()
             const cellSize = parseInt(window.getComputedStyle(element).getPropertyValue("--clips-width")) + 1 // gaps
             return Option.wrap({
                 update: ({clientX: newPosition}) => {
-                    const newValue = Math.max(0, beginValue + Math.round((newPosition - beginPosition) / cellSize))
+                    const newValue = Math.max(0, beginCount + Math.round((newPosition - beginPosition) / cellSize))
                     if (newValue === 0) {
                         clips.visible.setValue(false)
                         return
@@ -111,7 +112,10 @@ export const ClipsHeader = ({lifecycle, service}: Construct) => {
                     clips.count.setValue(clampClipCount(newValue, minimumCount))
                     clips.visible.setValue(true)
                 },
-                cancel: () => {}
+                cancel: () => {
+                    clips.count.setValue(beginCount)
+                    clips.visible.setValue(beginVisible)
+                }
             } satisfies Dragging.Process)
         })
     )

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/constants.ts
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/constants.ts
@@ -1,1 +1,20 @@
+import {clamp, int} from "@opendaw/lib-std"
+
 export const ClipWidth = 49 // make a better connection to the CSS variables and adjustable
+export const MaxClipCount: int = 9
+
+export const clampClipMoveDelta = (
+    requestedDelta: int,
+    clipIndices: ReadonlyArray<int>,
+    maxClipCount: int
+): int => clipIndices.reduce((delta, index) =>
+    clamp(delta, -index, maxClipCount - index - 1), requestedDelta)
+
+export const movedClipCount = (
+    minimumCount: int,
+    clipIndices: ReadonlyArray<int>,
+    delta: int
+): int => clipIndices.reduce((count, index) => Math.max(count, index + delta + 1), minimumCount)
+
+export const clampClipCount = (requestedCount: int, minimumCount: int): int =>
+    clamp(requestedCount, Math.max(1, minimumCount), Math.max(MaxClipCount, minimumCount))


### PR DESCRIPTION
## Summary

- cap interactive clip view growth at the existing nine-column design limit while preserving occupied legacy columns
- grow the visible clip count during a rightward clip drag so the preview and destination stay reachable
- restore the original count on cancellation and prevent resize from hiding occupied clips
- add regression coverage for movement, growth, and resize boundaries

## Verification

- `npm test --workspace @opendaw/app-studio` (24 tests passed)
- `npx tsc -p packages/app/studio/tsconfig.json --noEmit --pretty false`
- targeted ESLint on all changed TypeScript files (0 errors)

Fixes #185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio clip dragging so clips remain within valid timeline bounds.
  * Preserved the required number of clip columns when moving or resizing clips.
  * Canceling a clip move or resize now correctly restores the previous clip layout.
  * Resizing clip columns supports hiding clips while preventing invalid or excessive counts.

* **Tests**
  * Added coverage for clip movement, resizing limits, and automatic column expansion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->