### PR TITLE
ux: click to expand/collapse panels

### DIFF
--- a/packages/app/studio/src/ui/workspace/PanelPlaceholder.sass
+++ b/packages/app/studio/src/ui/workspace/PanelPlaceholder.sass
@@ -27,6 +27,16 @@ component
         margin-top: 0.5em
         margin-left: 0
 
+  &.minimizable
+    > header
+      cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m7 20 5-5 5 5'/%3E%3Cpath d='m7 4 5 5 5-5'/%3E%3C/svg%3E") 9 9, pointer
+
+    &.closed:not(.horizontal) > header
+      cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m7 15 5 5 5-5'/%3E%3Cpath d='m7 9 5-5 5 5'/%3E%3C/svg%3E") 9 9, pointer
+
+    &.horizontal.closed > header
+      cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m9 7-5 5 5 5'/%3E%3Cpath d='m15 7 5 5-5 5'/%3E%3C/svg%3E") 9 9, pointer
+
   > header
     font-size: 0.75em
     min-height: 1.5em

--- a/packages/app/studio/src/ui/workspace/PanelPlaceholder.tsx
+++ b/packages/app/studio/src/ui/workspace/PanelPlaceholder.tsx
@@ -29,7 +29,7 @@ export const PanelPlaceholder =
         const {icon, name, constrains, minimizable, popoutable} = panelState
         const HeaderSize = 18
         const container = <Group/>
-        const element: DomElement = <div className={Html.buildClassList(className, orientation)}
+        const element: DomElement = <div className={Html.buildClassList(className, orientation, minimizable && "minimizable")}
                                          data-panel-type={name}/>
         const panelContent = panelContents.getByType(panelState.panelType)
 
@@ -133,7 +133,9 @@ export const PanelPlaceholder =
             }
         }))
         appendChildren(element, <Frag>{header}{container}</Frag>)
-        lifecycle.own(Events.subscribeDblDwn(header, () => handler.toggleMinimize()))
+        if (minimizable) {
+            lifecycle.own(Events.subscribe(header, "click", () => handler.toggleMinimize()))
+        }
         lifecycle.own(ContextMenu.subscribe(header, collector => collector.addItems(
             MenuItem.default({
                 label: "Popout into new browser window",


### PR DESCRIPTION
First time user. First PR.

- Most noticeable UX issue for me: Took me time to figure out you need to double click a panel header to collapse/expend.
- Also added icons on hover (Icons are from https://lucide.dev/icons/chevrons-right-left).

https://github.com/user-attachments/assets/fefc1473-b1ec-4add-b900-46d76dcd654d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual cursor indicators for expandable and minimized panel states.
  * Panels marked as minimizable can now be toggled with a single click on the header.

* **Bug Fixes**
  * Prevented minimize actions on panels that do not support minimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->