### PR TITLE
feat(timeline): render automated parameter name on automation clips (#212 follow-up)

### DIFF
--- a/packages/app/studio/src/ui/timeline/TimelineLabels.test.ts
+++ b/packages/app/studio/src/ui/timeline/TimelineLabels.test.ts
@@ -5,9 +5,17 @@ import {
     NoteRegionBoxAdapter,
     ProjectSkeleton,
     TrackType,
+    ValueClipBoxAdapter,
     ValueRegionBoxAdapter
 } from "@opendaw/studio-adapters"
-import {NoteEventCollectionBox, NoteRegionBox, TrackBox, ValueEventCollectionBox, ValueRegionBox} from "@opendaw/studio-boxes"
+import {
+    NoteEventCollectionBox,
+    NoteRegionBox,
+    TrackBox,
+    ValueClipBox,
+    ValueEventCollectionBox,
+    ValueRegionBox
+} from "@opendaw/studio-boxes"
 import {TimelineLabels} from "@/ui/timeline/TimelineLabels"
 
 if (!isDefined(Reflect.get(globalThis, "AudioWorkletNode"))) {
@@ -55,6 +63,17 @@ const setup = async (resolvable: boolean) => {
             box.regions.refer(valueTrack.regions)
         })
     }).map(box => project.boxAdapters.adapterFor(box, ValueRegionBoxAdapter)).unwrap("value-region")
+    let clipIndex = 0
+    const valueClip = (label: string): ValueClipBoxAdapter => project.editing.modify(() => {
+        const events = ValueEventCollectionBox.create(boxGraph, UUID.generate())
+        return ValueClipBox.create(boxGraph, UUID.generate(), box => {
+            box.index.setValue(clipIndex++)
+            box.label.setValue(label)
+            box.duration.setValue(1920)
+            box.events.refer(events.owners)
+            box.clips.refer(valueTrack.clips)
+        })
+    }).map(box => project.boxAdapters.adapterFor(box, ValueClipBoxAdapter)).unwrap("value-clip")
     const noteRegion = (label: string): NoteRegionBoxAdapter => project.editing.modify(() => {
         const events = NoteEventCollectionBox.create(boxGraph, UUID.generate())
         return NoteRegionBox.create(boxGraph, UUID.generate(), box => {
@@ -65,7 +84,7 @@ const setup = async (resolvable: boolean) => {
             box.regions.refer(noteTrack.regions)
         })
     }).map(box => project.boxAdapters.adapterFor(box, NoteRegionBoxAdapter)).unwrap("note-region")
-    return {valueRegion, noteRegion}
+    return {valueRegion, valueClip, noteRegion}
 }
 
 describe("TimelineLabels.forRegion", () => {
@@ -96,5 +115,30 @@ describe("TimelineLabels.forRegion", () => {
         const {noteRegion} = await setup(true)
         expect(TimelineLabels.forRegion(noteRegion(""))).toBe("")
         expect(TimelineLabels.forRegion(noteRegion("Verse"))).toBe("Verse")
+    })
+})
+
+describe("TimelineLabels.forClip", () => {
+    it("shows the automated parameter name when the clip carries no custom label", async () => {
+        const {valueClip} = await setup(true)
+        expect(TimelineLabels.forClip(valueClip(""))).toBe("Volume")
+    })
+
+    it("appends a custom label behind the parameter name", async () => {
+        const {valueClip} = await setup(true)
+        expect(TimelineLabels.forClip(valueClip("Build-up"))).toBe("Volume · Build-up")
+    })
+
+    it("never repeats the parameter name, whatever recorded automation stored", async () => {
+        const {valueClip} = await setup(true)
+        expect(TimelineLabels.forClip(valueClip("volume"))).toBe("Volume")
+        expect(TimelineLabels.forClip(valueClip("Volume"))).toBe("Volume")
+        expect(TimelineLabels.forClip(valueClip("  volume  "))).toBe("Volume")
+    })
+
+    it("falls back to N/A when the parameter cannot be resolved", async () => {
+        const {valueClip} = await setup(false)
+        expect(TimelineLabels.forClip(valueClip(""))).toBe("N/A")
+        expect(TimelineLabels.forClip(valueClip("Build-up"))).toBe("N/A · Build-up")
     })
 })

--- a/packages/app/studio/src/ui/timeline/TimelineLabels.ts
+++ b/packages/app/studio/src/ui/timeline/TimelineLabels.ts
@@ -1,3 +1,4 @@
+import {Option} from "@opendaw/lib-std"
 import {
     AnyClipBoxAdapter,
     AnyRegionBoxAdapter,
@@ -5,6 +6,7 @@ import {
     AudioRegionBoxAdapter,
     NoteClipBoxAdapter,
     NoteRegionBoxAdapter,
+    TrackBoxAdapter,
     ValueClipBoxAdapter,
     ValueRegionBoxAdapter
 } from "@opendaw/studio-adapters"
@@ -15,24 +17,30 @@ const Unresolved = "N/A"
 
 const orPlaceholder = (label: string): string => label.length === 0 ? Placeholder : label
 
+// Value clips and regions render their automated parameter name, composed at draw time (#212), with any custom
+// label appended behind it. Recorded automation used to store the parameter name as its label, which would read
+// "Crush · Crush"; migration cannot clear those (parameter names live in the device adapters, not the saved
+// graph), so a custom label equal to the parameter name is treated as no custom label.
+const composeValueLabel = (label: string, trackBoxAdapter: Option<TrackBoxAdapter>): string => {
+    const parameter = trackBoxAdapter.flatMap(track => track.targetControlName).unwrapOrElse(Unresolved)
+    const custom = label.trim()
+    return custom.length === 0 || custom.toLowerCase() === parameter.toLowerCase()
+        ? parameter
+        : `${parameter}${Separator}${custom}`
+}
+
 export namespace TimelineLabels {
     export const forRegion = (adapter: AnyRegionBoxAdapter): string => adapter.accept({
         visitNoteRegionBoxAdapter: ({label}: NoteRegionBoxAdapter): string => label,
         visitAudioRegionBoxAdapter: ({label}: AudioRegionBoxAdapter): string => orPlaceholder(label),
-        visitValueRegionBoxAdapter: ({label, trackBoxAdapter}: ValueRegionBoxAdapter): string => {
-            const parameter = trackBoxAdapter.flatMap(track => track.targetControlName).unwrapOrElse(Unresolved)
-            // Recorded automation used to store the parameter name as its label, which would read "Crush · Crush".
-            // Migration cannot clear those: parameter names live in the device adapters, not in the saved graph.
-            const custom = label.trim()
-            return custom.length === 0 || custom.toLowerCase() === parameter.toLowerCase()
-                ? parameter
-                : `${parameter}${Separator}${custom}`
-        }
+        visitValueRegionBoxAdapter: ({label, trackBoxAdapter}: ValueRegionBoxAdapter): string =>
+            composeValueLabel(label, trackBoxAdapter)
     }) ?? adapter.label
 
     export const forClip = (adapter: AnyClipBoxAdapter): string => adapter.accept({
         visitNoteClipBoxAdapter: ({label}: NoteClipBoxAdapter): string => label,
         visitAudioClipBoxAdapter: ({label}: AudioClipBoxAdapter): string => orPlaceholder(label),
-        visitValueClipBoxAdapter: ({label}: ValueClipBoxAdapter): string => label
+        visitValueClipBoxAdapter: ({label, trackBoxAdapter}: ValueClipBoxAdapter): string =>
+            composeValueLabel(label, trackBoxAdapter)
     }) ?? adapter.label
 }

--- a/plans/automation-clip-label.md
+++ b/plans/automation-clip-label.md
@@ -6,8 +6,8 @@
 
 ## Context
 
-#212 made automation labels render the bound parameter's name, composed at draw time, instead of the literal
-"Automation". The label is stored empty and `TimelineLabels` composes the visible string from the track's
+Issue #212 made automation labels render the bound parameter's name, composed at draw time, instead of the
+literal "Automation". The label is stored empty and `TimelineLabels` composes the visible string from the track's
 `targetControlName` plus any custom text (`MigrateDefaultLabels` clears the old stored defaults).
 
 That work landed for **value regions** (the arranger): `TimelineLabels.forRegion`'s
@@ -15,7 +15,7 @@ That work landed for **value regions** (the arranger): `TimelineLabels.forRegion
 (`TimelineLabels.forClip`'s `visitValueClipBoxAdapter`) was left returning the raw stored `label`. Because
 clips are now created with an empty label and the migration clears the old "Automation" default, an
 automation **clip** in the clip-launcher renders **nothing** instead of its parameter name — the exact gap
-#212 set out to close, just on the other surface.
+issue #212 set out to close, just on the other surface.
 
 ## Root cause
 

--- a/plans/automation-clip-label.md
+++ b/plans/automation-clip-label.md
@@ -1,0 +1,48 @@
+# Automation clip labels: parameter name at draw time (follow-up to #212)
+
+**Type:** feature (completes #212 on the clip-launcher surface)
+**Scope:** small — one shared helper, the value-clip visitor, tests.
+**Assisted:** Claude Code. Verified against the #212 implementation (commit `0ab4a90c7`) before editing.
+
+## Context
+
+#212 made automation labels render the bound parameter's name, composed at draw time, instead of the literal
+"Automation". The label is stored empty and `TimelineLabels` composes the visible string from the track's
+`targetControlName` plus any custom text (`MigrateDefaultLabels` clears the old stored defaults).
+
+That work landed for **value regions** (the arranger): `TimelineLabels.forRegion`'s
+`visitValueRegionBoxAdapter` composes `parameter` / `parameter · custom`. But the **value clip** path
+(`TimelineLabels.forClip`'s `visitValueClipBoxAdapter`) was left returning the raw stored `label`. Because
+clips are now created with an empty label and the migration clears the old "Automation" default, an
+automation **clip** in the clip-launcher renders **nothing** instead of its parameter name — the exact gap
+#212 set out to close, just on the other surface.
+
+## Root cause
+
+`ValueClipBoxAdapter` already exposes `trackBoxAdapter: Option<TrackBoxAdapter>` and
+`TrackBoxAdapter.targetControlName: Option<string>` — the same accessors the region path uses. The clip
+visitor simply did not use them:
+
+```ts
+visitValueClipBoxAdapter: ({label}: ValueClipBoxAdapter): string => label   // ignores the parameter
+```
+
+## Fix
+
+Extract the region path's composition into a shared `composeValueLabel(label, trackBoxAdapter)` and use it in
+**both** the region and clip visitors, so the two surfaces stay identical by construction (parameter name,
+`parameter · custom` when a real custom label is present, `N/A` when the parameter cannot be resolved, and
+the "never repeat the parameter name" guard for recorded automation). No behavioural change to note/audio
+labels.
+
+## Tests
+
+`TimelineLabels.test.ts` — new `TimelineLabels.forClip` block mirroring the existing `forRegion` cases
+(parameter name when unlabelled, custom appended, parameter never repeated, `N/A` fallback on an unresolvable
+track). Proven RED→GREEN: reverting the clip visitor to `label` fails exactly those four cases.
+
+## Verification
+
+- `TimelineLabels` suite: 9 passed (5 region + 4 new clip).
+- Touched files add no new `tsc --noEmit` errors and no new eslint errors (the file's pre-existing
+  `no-namespace` is repo-wide baseline, unchanged by this diff).


### PR DESCRIPTION
## Summary

Completes **#212** on the clip-launcher surface. #212 made automation labels render the **bound parameter's name**, composed at draw time (labels are stored empty; `MigrateDefaultLabels` clears the old `"Automation"`). That landed for value **regions** (the arranger) but the value **clip** path was left returning the raw stored label — so an automation *clip* now renders **nothing** instead of its parameter name.

## Before / after

| Surface | Before this PR | After |
|---|---|---|
| Value **region** (arranger) | `Volume`, `Volume · Build-up` ✅ (from #212) | unchanged |
| Value **clip** (clip-launcher) | *(empty)* ❌ | `Volume`, `Volume · Build-up` ✅ |

## Change

`ValueClipBoxAdapter` already exposes `trackBoxAdapter → TrackBoxAdapter.targetControlName` — the exact accessors the region path uses. The region composition is extracted into a shared `composeValueLabel(label, trackBoxAdapter)` and applied to **both** the region and clip visitors, so the two surfaces stay identical by construction:

- parameter name when there is no custom label,
- `` `${parameter} · ${custom}` `` for a real custom label,
- `N/A` when the parameter can't be resolved,
- and the existing "never repeat the parameter name" guard for recorded automation (`Crush · Crush` → `Crush`).

Note/audio labels are unchanged.

## Tests

- New `TimelineLabels.forClip` describe block mirroring the existing `forRegion` cases (parameter name when unlabelled, custom appended, parameter never repeated, `N/A` fallback on an unresolvable track).
- **Proven RED→GREEN**: reverting the clip visitor to `label` fails exactly those four cases.
- `TimelineLabels` suite: **9 passed** (5 region + 4 new clip).

## Verification

Touched files add **no new** `tsc --noEmit` errors and **no new** eslint errors (the file's pre-existing `no-namespace` is repo-wide baseline, unchanged by this diff).

## Notes

AI-assisted (Claude Code); verified against the #212 implementation (`0ab4a90c7`) before editing. Single focused change, independent of my other open PR (#364). Process documented in [`plans/automation-clip-label.md`](https://github.com/56steve/openDAW/blob/feat/automation-clip-parameter-name/plans/automation-clip-label.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automation clip labels now include the associated parameter name, with custom labels shown when provided.
  * Clip and region labels use consistent formatting.

* **Tests**
  * Added coverage for label behavior across automation clips and value regions.

* **Documentation**
  * Added a plan documenting automation clip label behavior and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->