### PR TITLE
fix(engine): stop count-in metronome at recording_start (#367)

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1470,6 +1470,11 @@ impl Engine {
             self.is_recording = true;
             self.metronome.set_enabled(self.metronome_pref);
         }
+        // The flip above is quantum-granular; when the metronome is forced on ONLY for the count-in (the
+        // preference is off), cap its clicks at recording_start so the punch-in downbeat does not leak a
+        // block past the boundary (#367). A preference-driven metronome stays unbounded.
+        self.metronome.set_click_ceiling(
+            if self.is_counting_in && !self.metronome_pref {self.recording_start} else {f64::INFINITY});
         let recording_start = self.recording_start;
         let denominator = self.recording_denominator;
         let sample_rate = self.sample_rate;

--- a/crates/engine/src/metronome.rs
+++ b/crates/engine/src/metronome.rs
@@ -125,7 +125,8 @@ pub struct Metronome {
     gain_db: f32,
     monophonic: bool,
     sample_rate: f32,
-    enabled: bool
+    enabled: bool,
+    click_ceiling: f64 // exclusive pulse beyond which no click schedules; INFINITY = unbounded (#367)
 }
 
 impl Metronome {
@@ -138,12 +139,22 @@ impl Metronome {
             gain_db: -6.0,
             monophonic: true,
             sample_rate,
-            enabled: true
+            enabled: true,
+            click_ceiling: f64::INFINITY
         }
     }
 
     pub fn set_enabled(&mut self, enabled: bool) {
         self.enabled = enabled
+    }
+
+    /// Stop scheduling clicks at (and past) `pulse`. The engine sets this to `recording_start` while the
+    /// metronome is forced on for a count-in but the preference is off, so the punch-in downbeat does not
+    /// leak: the count-in -> recording flip is quantum-granular, so without a sample-accurate ceiling a
+    /// `recording_start` landing mid-quantum renders one extra click (TS split the block at that point). Set
+    /// `f64::INFINITY` for the unbounded (preference-driven) metronome.
+    pub fn set_click_ceiling(&mut self, pulse: f64) {
+        self.click_ceiling = pulse
     }
 
     pub fn set_gain(&mut self, gain_db: f32) {
@@ -188,6 +199,9 @@ impl Metronome {
                 // the storage entry covers the count-in's NEGATIVE pulses too (TS: index -1 -> p0 as-is)
                 let region_start = if curr.index == -1 || block.p0 > signature_start {block.p0} else {signature_start};
                 let region_end = if block.p1 < signature_end {block.p1} else {signature_end};
+                // Clamp to the count-in click ceiling so the punch-in downbeat at recording_start is not
+                // scheduled when the metronome is only forced on for the count-in (#367).
+                let region_end = if region_end < self.click_ceiling {region_end} else {self.click_ceiling};
                 let denominator = curr.denominator * self.beat_sub_division;
                 let step_size = from_signature(1, denominator);
                 if step_size <= 0.0 {
@@ -324,6 +338,41 @@ mod tests {
         let signature = [storage(3, 4)];
         let clicks = render_impulses(&mut metronome, &signature, -2880.0, quanta_for(2880.0));
         assert_click_train(&clicks, &[(0.0, 1.0), (960.0, 0.5), (1920.0, 0.5)]);
+    }
+
+    #[test]
+    fn count_in_click_ceiling_suppresses_the_punch_in_downbeat() {
+        // #367: recording_start (the "1" after "1 2 3 4") falls strictly inside a quantum, so the
+        // quantum-granular count-in -> recording flip has not fired yet and the forced-on metronome would
+        // schedule the boundary downbeat. A block straddling pulse 0 (p0 < 0 < p1) reproduces that.
+        let signature = [storage(4, 4)];
+        let step = samples_to_pulses(QUANTUM as f64, BPM, SAMPLE_RATE);
+        let block = Block {p0: -step / 2.0, p1: step / 2.0, s0: 0, s1: QUANTUM, bpm: BPM, discontinuous: false};
+        let mut leaked = impulse_metronome();
+        let mut left = [0.0f32; QUANTUM];
+        let mut right = [0.0f32; QUANTUM];
+        leaked.process(&block, &signature, &mut left, &mut right);
+        assert!(left.iter().any(|value| *value != 0.0), "without a ceiling the boundary downbeat leaks");
+        let mut suppressed = impulse_metronome();
+        suppressed.set_click_ceiling(0.0); // recording_start
+        let mut left = [0.0f32; QUANTUM];
+        let mut right = [0.0f32; QUANTUM];
+        suppressed.process(&block, &signature, &mut left, &mut right);
+        assert!(left.iter().all(|value| *value == 0.0), "the ceiling suppresses the punch-in downbeat (#367)");
+    }
+
+    #[test]
+    fn count_in_click_ceiling_keeps_the_count_in_beats() {
+        // The ceiling must cut ONLY at/after recording_start: a count-in beat strictly before it still sounds.
+        let signature = [storage(4, 4)];
+        let step = samples_to_pulses(QUANTUM as f64, BPM, SAMPLE_RATE);
+        let block = Block {p0: -960.0 - step / 2.0, p1: -960.0 + step / 2.0, s0: 0, s1: QUANTUM, bpm: BPM, discontinuous: false};
+        let mut metronome = impulse_metronome();
+        metronome.set_click_ceiling(0.0); // recording_start, well past this block
+        let mut left = [0.0f32; QUANTUM];
+        let mut right = [0.0f32; QUANTUM];
+        metronome.process(&block, &signature, &mut left, &mut right);
+        assert!(left.iter().any(|value| *value != 0.0), "the -960 count-in beat still sounds below the ceiling");
     }
 
     #[test]

--- a/plans/countin-metronome-boundary-click.md
+++ b/plans/countin-metronome-boundary-click.md
@@ -1,0 +1,55 @@
+# Count-in metronome: sample-accurate click ceiling (#367)
+
+**Type:** bug fix (WASM engine regression vs the old TS engine)
+**Scope:** small — one field + setter on `Metronome`, one clamp in `Metronome::process`, one line in the engine's per-quantum setup.
+**Assisted:** Claude Code. Root cause was pinned by the reporter (naomiaro, #367); verified against the engine source before editing.
+
+## Symptom
+
+With the metronome preference **disabled** and a count-in enabled, starting a recording can play one extra
+click exactly at the punch-in downbeat: a 1-bar 4/4 count-in sounds as **1 2 3 4 — 1** instead of **1 2 3 4**.
+The old TS engine was correct; the regression window is the TS→WASM engine transition. Audibility is
+alignment-dependent (always leaks at 44.1 kHz / 120 BPM; some 48 kHz configs mask it).
+
+## Root cause (`crates/engine/src/lib.rs`, `crates/engine/src/metronome.rs`)
+
+1. The metronome is forced on during count-in regardless of the preference (`apply_metronome`:
+   `enabled = metronome_pref || is_counting_in`).
+2. The count-in → recording flip is **quantum-granular** — it tests the block *start* position:
+   `if self.is_counting_in && self.transport.position() >= self.recording_start { … set_enabled(pref) }`.
+3. When `recording_start` falls **strictly inside** a quantum, the flip has not fired for that block, the
+   metronome is still forced on, and `Metronome::process` schedules every beat in `[p0, p1)` — including the
+   punch-in downbeat at exactly `recording_start`. The flip then lands on the *next* quantum.
+
+The TS engine split the render block at `recording_start`, so the boundary beat fell in the post-flip half
+and was suppressed when the preference was off. The WASM engine processes the whole quantum with the
+metronome state fixed at block start, so the boundary click leaks.
+
+## Fix
+
+Give the metronome a sample-accurate **exclusive click ceiling** — the pulse beyond which no click
+schedules — reproducing what the TS block split achieved without splitting the block:
+
+- `Metronome`: new `click_ceiling: f64` (default `f64::INFINITY`) + `set_click_ceiling(pulse)`. In
+  `process`, `region_end` is clamped to `min(region_end, click_ceiling)`, so the `while position <
+  region_end` loop never schedules a beat at or past the ceiling.
+- Engine per-quantum (right after the count-in flip): set the ceiling to `recording_start` while the
+  metronome is forced on **only** for the count-in (`is_counting_in && !metronome_pref`), else
+  `f64::INFINITY`. A preference-driven metronome stays unbounded and plays through the punch-in, unchanged.
+
+The count-in beats (all strictly before `recording_start`) are untouched; only the boundary downbeat — the
+first *recorded* beat, not a count-in beat — is suppressed when the metronome is off.
+
+## Tests (`crates/engine/src/metronome.rs`, native `cargo test`)
+
+- `count_in_click_ceiling_suppresses_the_punch_in_downbeat` — a block straddling the recording_start pulse
+  (`p0 < recording_start < p1`, the mid-quantum case): the boundary downbeat sounds with no ceiling and is
+  silent with the ceiling set. **Proven RED→GREEN**: removing the clamp fails exactly this test.
+- `count_in_click_ceiling_keeps_the_count_in_beats` — a count-in beat strictly below the ceiling still
+  sounds, so the ceiling cuts only at/after `recording_start`.
+
+## Verification
+
+- `cargo test -p engine`: **181 passed** (179 existing + 2 new).
+- `cargo build -p engine --target wasm32-unknown-unknown`: compiles clean (no_std real target).
+- No new clippy warnings in the changed files.


### PR DESCRIPTION
Fixes #367.

## Symptom

With the metronome **preference off** and a count-in enabled, starting a recording leaks one extra click at the punch-in downbeat — a 1-bar 4/4 count-in sounds as **1 2 3 4 — 1** instead of **1 2 3 4**. The recording itself is click-free, so it's exactly the boundary click. The old TS engine was correct; this regressed in the TS→WASM transition. Audibility is alignment-dependent (always leaks at 44.1 kHz / 120 BPM; some 48 kHz configs mask it), which is why it reads as intermittent.

## Root cause

1. The metronome is forced on during count-in regardless of the preference (`apply_metronome`: `enabled = metronome_pref || is_counting_in`).
2. The count-in → recording flip is **quantum-granular** — it tests the block *start* position (`lib.rs`, ~1468):
   ```rust
   if self.is_counting_in && self.transport.position() >= self.recording_start { … set_enabled(pref) }
   ```
3. When `recording_start` falls **strictly inside** a quantum, the flip hasn't fired for that block, the metronome is still forced on, and `Metronome::process` schedules every beat in `[p0, p1)` — including the punch-in downbeat at exactly `recording_start`. The flip lands on the *next* quantum.

The TS engine split the render block at `recording_start`, so the boundary beat fell in the post-flip half and was suppressed when the preference was off.

## Fix

Give `Metronome` a sample-accurate **exclusive click ceiling** — reproducing the TS block split without splitting the block:

- `Metronome`: new `click_ceiling: f64` (default `f64::INFINITY`) + `set_click_ceiling`; `process()` clamps `region_end` to `min(region_end, click_ceiling)`, so the `while position < region_end` loop never schedules a beat at/past the ceiling.
- Engine per-quantum (right after the flip): ceiling = `recording_start` while the metronome is forced on **only** for the count-in (`is_counting_in && !metronome_pref`), else `f64::INFINITY`.

Count-in beats (all strictly before `recording_start`) are untouched; a preference-driven metronome stays unbounded and plays through the punch-in unchanged. No detector/assert softened.

## Tests (native `cargo test`, no WASM needed)

- `count_in_click_ceiling_suppresses_the_punch_in_downbeat` — a block straddling `recording_start` (`p0 < recording_start < p1`): the boundary downbeat sounds with no ceiling, is silent with the ceiling. **Proven RED→GREEN** (removing the clamp fails exactly this test).
- `count_in_click_ceiling_keeps_the_count_in_beats` — a count-in beat strictly below the ceiling still sounds, so the ceiling cuts only at/after `recording_start`.

## Verification

- `cargo test -p engine`: **181 passed** (179 existing + 2 new).
- `cargo build -p engine --target wasm32-unknown-unknown`: compiles clean (no_std real target).
- No new clippy warnings in the changed files.

## Notes

AI-assisted (Claude Code); the root cause was pinned by @naomiaro in #367, verified against the engine source before editing. Thanks for the excellent report. Process documented in [`plans/countin-metronome-boundary-click.md`](https://github.com/56steve/openDAW/blob/fix/countin-metronome-boundary-click/plans/countin-metronome-boundary-click.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an extra metronome click sounding at the punch-in recording boundary when the metronome is enabled only during count-in.
  * Preserved count-in clicks before the recording start while preventing clicks beyond the boundary.
* **Tests**
  * Added coverage for metronome boundary behavior and count-in timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->