### PR TITLE
fix(ui): don't overwrite a focused number/timecode field on external model change (#369)

### DIFF
--- a/packages/app/studio/src/ui/components/NumberInput.tsx
+++ b/packages/app/studio/src/ui/components/NumberInput.tsx
@@ -39,19 +39,26 @@ export const NumberInput = ({
             {input}
         </div>
     )
-    const updateDigits = () => {
+    let editing = false
+    const updateDigits = (force: boolean = false) => {
         const value = model.getValue()
         element.classList.toggle("negative", negativeWarning === true && value < 0)
+        // While the field is focused the user's in-progress text is authoritative; an external model change
+        // (e.g. the property-table writing the focus note's values back) must not overwrite it (#369). Only
+        // this field's own edits (Arrow/Enter) force a refresh.
+        if (editing && !force) {return}
         input.textContent = mapper.x(value).value
     }
     lifecycle.ownAll(
-        model.subscribe(updateDigits),
+        model.subscribe(() => updateDigits()),
         Events.subscribe(element, "focusin", (event: Event) => {
             if (!isInstanceOf(event.target, HTMLElement)) {return}
+            editing = true
             Html.selectContent(event.target)
         }),
         Events.subscribe(element, "focusout", (event: Event) => {
             if (!isInstanceOf(event.target, HTMLElement)) {return}
+            editing = false
             const result = mapper.y(event.target.textContent ?? "")
             if (result.type === "explicit" && !isNaN(result.value)) {
                 model.setValue(isDefined(guard) ? guard.guard(result.value) : result.value)
@@ -74,6 +81,7 @@ export const NumberInput = ({
                 if (status === "success" && json.app === "openDAW" && json.content === "number") {
                     event.preventDefault()
                     model.setValue(isDefined(guard) ? guard.guard(json.value) : json.value)
+                    updateDigits(true) // reflect the paste while focused, else focusout reverts to the old text
                 }
             }
         }),
@@ -88,6 +96,7 @@ export const NumberInput = ({
                     if (result.type !== "explicit" || isNaN(result.value)) {return}
                     const nextValue: int = result.value + step
                     model.setValue(isDefined(guard) ? guard.guard(nextValue) : nextValue)
+                    updateDigits(true)
                     Html.selectContent(target)
                     break
                 }
@@ -97,6 +106,7 @@ export const NumberInput = ({
                     if (result.type !== "explicit" || isNaN(result.value)) {return}
                     const nextValue: int = result.value - step
                     model.setValue(isDefined(guard) ? guard.guard(nextValue) : nextValue)
+                    updateDigits(true)
                     Html.selectContent(target)
                     break
                 }

--- a/packages/app/studio/src/ui/components/TimeCodeInput.tsx
+++ b/packages/app/studio/src/ui/components/TimeCodeInput.tsx
@@ -46,10 +46,15 @@ export const TimeCodeInput = ({lifecycle, model, className, negativeWarning, sig
             {inputs}
         </div>
     )
-    const updateDigits = () => {
+    let editing = false
+    const updateDigits = (force: boolean = false) => {
         const value = model.getValue()
         const negative = value < 0
         element.classList.toggle("negative", negativeWarning === true && negative)
+        // While a sub-field is focused, do not overwrite the user's in-progress text with an external model
+        // change (e.g. the property-table writing the focus note's values back) — that jumps the field back to
+        // the previous number (#369). Only this field's own edits (Arrow/Enter) force a refresh.
+        if (editing && !force) {return}
         const {bars, beats, semiquavers, ticks} = PPQN.toParts(value, upper, lower)
         inputs[0].textContent = negative ? String(bars) : String(bars + barOffset()).padStart(3, "0")
         inputs[1].textContent = String(beats + subOffset)
@@ -57,16 +62,22 @@ export const TimeCodeInput = ({lifecycle, model, className, negativeWarning, sig
         inputs[3].textContent = String(ticks).padStart(3, "0")
     }
     if (oneBased === true) {
-        lifecycle.own(StudioPreferences.subscribe(updateDigits, "time-display", "count-bars-from-zero"))
+        lifecycle.own(StudioPreferences.subscribe(() => updateDigits(), "time-display", "count-bars-from-zero"))
     }
     lifecycle.ownAll(
-        model.subscribe(updateDigits),
+        model.subscribe(() => updateDigits()),
         Events.subscribe(element, "focusin", (event: Event) => {
             if (!isInstanceOf(event.target, HTMLElement)) {return}
+            editing = true
             Html.selectContent(event.target)
         }),
-        Events.subscribe(element, "focusout", (event: Event) => {
+        Events.subscribe(element, "focusout", (event: FocusEvent) => {
             if (!isInstanceOf(event.target, HTMLElement)) {return}
+            // focusout bubbles from every sub-field: moving between them is still editing, so only end
+            // editing (and flush any deferred model change) once focus leaves the whole element (#369).
+            if (isInstanceOf(event.relatedTarget, Node) && element.contains(event.relatedTarget)) {return}
+            editing = false
+            updateDigits()
             Html.unselectContent(event.target)
         }),
         Events.subscribe(element, "copy", (event: ClipboardEvent) => {
@@ -85,6 +96,7 @@ export const TimeCodeInput = ({lifecycle, model, className, negativeWarning, sig
                 if (safeRead(json, "app") === "openDAW" && safeRead(json, "content") === "timecode") {
                     event.preventDefault()
                     model.setValue(json.value ?? 0)
+                    updateDigits(true) // reflect the paste while focused, else the parts stay stale
                 }
             }
         }),
@@ -97,12 +109,14 @@ export const TimeCodeInput = ({lifecycle, model, className, negativeWarning, sig
                 case "ArrowUp": {
                     event.preventDefault()
                     model.setValue(model.getValue() + units[index].amount)
+                    updateDigits(true)
                     Html.selectContent(target)
                     break
                 }
                 case "ArrowDown": {
                     event.preventDefault()
                     model.setValue(model.getValue() - units[index].amount)
+                    updateDigits(true)
                     Html.selectContent(target)
                     break
                 }
@@ -117,9 +131,10 @@ export const TimeCodeInput = ({lifecycle, model, className, negativeWarning, sig
                         + units[2].amount * (index === 2 ? unit - subOffset : semiquavers)
                         + units[3].amount * (index === 3 ? unit : ticks)
                     if (prevValue === nextValue) {
-                        updateDigits()
+                        updateDigits(true)
                     } else {
                         model.setValue(nextValue)
+                        updateDigits(true)
                     }
                     Html.selectContent(target)
                     break


### PR DESCRIPTION
Fixes #369.

## Cause

`NumberInput` and `TimeCodeInput` subscribe to their model and **unconditionally** rewrite the field's `textContent`:

```ts
model.subscribe(updateDigits) // updateDigits() { input.textContent = mapper.x(model.getValue()).value }
```

In the note property-table a single edit applies to **every** selected note, and the deferred `updateState` then writes the focus note's values back into the shared parameters (`PropertyTable.tsx`). When that write-back lands while you have tabbed on to the next field, the field's own `model.subscribe` handler overwrites what you are typing — it "jumps back to previous numbers".

## Fix

Guard the model → DOM sync: while a (sub-)field is focused, skip rewriting its `textContent` from an external model change. Only the field's own edits force a refresh — Arrow keys and Enter pass `force = true`, and blur commits then syncs. Non-focused fields are unaffected, so the panel still catches up on selection / modifier changes.

Same one-line guard (`if (editing && !force) return`) in both shared inputs, plus `focusin`/`focusout` toggling `editing` and the Arrow/Enter self-edits forcing a refresh.

## Verification

DOM components aren't unit-tested in this package (node-only app tests), so this was verified end-to-end in the running studio (built `tsc && vite build`, WASM engine live):

- Reproduced the exact #369 setup: new project → synth track → note region → note editor → **two notes, multi-selected** → property table rendered.
- Edited the velocity field through the real `focusin`/`focusout` path: **79 → 55**, committed, field synced, and `invalid` (mixed-value) class absent → the value propagated to **both** selected notes.
- `ArrowUp` while focused: **88 → 89 → 90**, committed to both notes — proving the field is in editing mode (so the guard is active) *and* the `force` refresh path works. A non-forced external update hits the same `editing` gate and is skipped — exactly what stops the clobber.
- No console errors.

Rationale is in the commit message (no plan file). Repro for a manual check: note editor, select >1 note, edit a field and tab to the next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented external updates from overwriting values while editing number and time-code fields.
  * Improved focus and blur behavior for in-progress text entry.
  * Ensured pasted values and arrow-key or Enter-key changes appear immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->