### PR TITLE
fix(recording): anchor takes on the engine's own recording start and keep the buffer head

### DIFF
--- a/packages/studio/adapters/src/protocols.ts
+++ b/packages/studio/adapters/src/protocols.ts
@@ -41,5 +41,9 @@ export interface EngineToClient {
     fetchNamWasm(): Promise<ArrayBuffer>
     notifyClipSequenceChanges(changes: ClipSequencingUpdates): void
     switchMarkerState(state: Nullable<[UUID.Bytes, int]>): void
+    // The transport began recording during the render quantum that ended at `contextTime` (audio-thread
+    // clock) and left the playhead at `position`. Both describe the same instant, so a capture can pair
+    // its own audio-thread anchors with the timeline without reading the main-thread state observables.
+    recordingStarted(contextTime: number, position: ppqn): void
     ready(): void
 }

--- a/packages/studio/adapters/src/protocols.ts
+++ b/packages/studio/adapters/src/protocols.ts
@@ -11,7 +11,7 @@ export interface EngineCommands extends Terminable {
     stop(reset: boolean): void
     setPosition(position: ppqn): void
     /** @internal */
-    prepareRecordingState(countIn: boolean): void
+    prepareRecordingState(countIn: boolean, generation: int): void
     /** @internal */
     stopRecording(): void
     queryLoadingComplete(): Promise<boolean>
@@ -44,6 +44,7 @@ export interface EngineToClient {
     // The transport began recording during the render quantum that ended at `contextTime` (audio-thread
     // clock) and left the playhead at `position`. Both describe the same instant, so a capture can pair
     // its own audio-thread anchors with the timeline without reading the main-thread state observables.
-    recordingStarted(contextTime: number, position: ppqn): void
+    // `generation` echoes the `prepareRecordingState` call the report belongs to.
+    recordingStarted(contextTime: number, position: ppqn, generation: int): void
     ready(): void
 }

--- a/packages/studio/core-processors/src/RecordingProcessor.ts
+++ b/packages/studio/core-processors/src/RecordingProcessor.ts
@@ -2,14 +2,27 @@ import {RecordingProcessorOptions, RingBuffer} from "@opendaw/studio-adapters"
 
 export class RecordingProcessor extends AudioWorkletProcessor {
     readonly #writer: RingBuffer.Writer
+    readonly #numberOfChannels: number
+
+    #announcedFirstQuantum: boolean = false
 
     constructor({processorOptions: config}: { processorOptions: RecordingProcessorOptions } & AudioNodeOptions) {
         super()
 
+        this.#numberOfChannels = config.numberOfChannels
         this.#writer = RingBuffer.writer(config)
     }
 
     process(inputs: ReadonlyArray<ReadonlyArray<Float32Array>>): boolean {
+        if (!this.#announcedFirstQuantum && inputs[0]?.length === this.#numberOfChannels) {
+            this.#announcedFirstQuantum = true
+            // Report the audio-thread time of the buffer's first frame, once, under the same
+            // channel-count gate the ring writer applies (setup-phase quanta arrive without
+            // channels and are not written). The main thread pairs it with the engine's own
+            // audio-thread anchors; the ring reader's frame counter cannot serve as that clock
+            // because chunk delivery trails the audio thread.
+            this.port.postMessage({type: "first-quantum", contextTime: currentTime})
+        }
         this.#writer.write(inputs[0])
         return true
     }

--- a/packages/studio/core-processors/src/global.d.ts
+++ b/packages/studio/core-processors/src/global.d.ts
@@ -8,3 +8,4 @@ declare interface AudioNodeOptions {
 }
 
 declare const sampleRate: number
+declare const currentTime: number

--- a/packages/studio/core-wasm/src/offline-worker.ts
+++ b/packages/studio/core-wasm/src/offline-worker.ts
@@ -127,8 +127,8 @@ Communicator.executor<OfflineEngineProtocol>(
                     switchMarkerState(markerState: Nullable<[UUID.Bytes, int]>): void {
                         dispatcher.dispatchAndForget(this.switchMarkerState, markerState)
                     }
-                    recordingStarted(contextTime: number, position: ppqn): void {
-                        dispatcher.dispatchAndForget(this.recordingStarted, contextTime, position)
+                    recordingStarted(contextTime: number, position: ppqn, generation: int): void {
+                        dispatcher.dispatchAndForget(this.recordingStarted, contextTime, position, generation)
                     }
                     ready() {dispatcher.dispatchAndForget(this.ready)}
                 })
@@ -248,7 +248,7 @@ Communicator.executor<OfflineEngineProtocol>(
                     if (reset) {engine.stop()}
                 },
                 setPosition: (position: ppqn): void => engine.set_position(position),
-                prepareRecordingState: (_countIn: boolean): void => {},
+                prepareRecordingState: (_countIn: boolean, _generation: int): void => {},
                 stopRecording: (): void => {},
                 queryLoadingComplete: (): Promise<boolean> => Promise.all(pending).then(() => true),
                 panic: (): void => {},

--- a/packages/studio/core-wasm/src/offline-worker.ts
+++ b/packages/studio/core-wasm/src/offline-worker.ts
@@ -127,6 +127,9 @@ Communicator.executor<OfflineEngineProtocol>(
                     switchMarkerState(markerState: Nullable<[UUID.Bytes, int]>): void {
                         dispatcher.dispatchAndForget(this.switchMarkerState, markerState)
                     }
+                    recordingStarted(contextTime: number, position: ppqn): void {
+                        dispatcher.dispatchAndForget(this.recordingStarted, contextTime, position)
+                    }
                     ready() {dispatcher.dispatchAndForget(this.ready)}
                 })
             const engine = instantiateWasmEngine(modules, memory, config.sampleRate, engineToClient)

--- a/packages/studio/core-wasm/src/processor.ts
+++ b/packages/studio/core-wasm/src/processor.ts
@@ -83,6 +83,7 @@ class WasmEngineProcessor extends AudioWorkletProcessor {
     #perfWriteIndex: int = 0
     #playbackTimestamp: ppqn = 0.0 // this is where we start playing again (after paused)
     readonly #recordingStartEdge: RecordingStartEdge = new RecordingStartEdge()
+    #recordingGeneration: int = 0
 
     constructor({processorOptions}: {processorOptions: EngineProcessorAttachment} & AudioNodeOptions) {
         super()
@@ -105,8 +106,8 @@ class WasmEngineProcessor extends AudioWorkletProcessor {
                 switchMarkerState(state: Nullable<[UUID.Bytes, int]>): void {
                     dispatcher.dispatchAndForget(this.switchMarkerState, state)
                 }
-                recordingStarted(contextTime: number, position: ppqn): void {
-                    dispatcher.dispatchAndForget(this.recordingStarted, contextTime, position)
+                recordingStarted(contextTime: number, position: ppqn, generation: int): void {
+                    dispatcher.dispatchAndForget(this.recordingStarted, contextTime, position, generation)
                 }
                 ready() {dispatcher.dispatchAndForget(this.ready)}
             })
@@ -193,8 +194,9 @@ class WasmEngineProcessor extends AudioWorkletProcessor {
                     this.#playbackTimestamp = position
                     engine.set_position(position)
                 }),
-                prepareRecordingState: (countIn: boolean): void => this.#guarded(() => {
+                prepareRecordingState: (countIn: boolean, generation: int): void => this.#guarded(() => {
                     this.#transporting = true
+                    this.#recordingGeneration = generation
                     engine.prepare_recording_state(countIn ? 1 : 0,
                         this.#preferences.settings.recording.countInBars)
                 }),
@@ -392,7 +394,8 @@ class WasmEngineProcessor extends AudioWorkletProcessor {
     #announceRecordingStart(engine: EngineExports): void {
         const view = new DataView(this.#memory.buffer, engine.engine_state_ptr(), engine.engine_state_len())
         if (this.#recordingStartEdge.observe(view.getUint8(18) === 1)) {
-            this.#engineToClient.recordingStarted(currentTime + RenderQuantum / sampleRate, view.getFloat32(0))
+            this.#engineToClient.recordingStarted(currentTime + RenderQuantum / sampleRate, view.getFloat32(0),
+                this.#recordingGeneration)
         }
     }
 

--- a/packages/studio/core-wasm/src/processor.ts
+++ b/packages/studio/core-wasm/src/processor.ts
@@ -83,7 +83,7 @@ class WasmEngineProcessor extends AudioWorkletProcessor {
     #perfWriteIndex: int = 0
     #playbackTimestamp: ppqn = 0.0 // this is where we start playing again (after paused)
     readonly #recordingStartEdge: RecordingStartEdge = new RecordingStartEdge()
-    #recordingGeneration: int = 0
+    #recordingGeneration: int = -1 // the client counts from 1, so a report before any prepare never matches
 
     constructor({processorOptions}: {processorOptions: EngineProcessorAttachment} & AudioNodeOptions) {
         super()

--- a/packages/studio/core-wasm/src/processor.ts
+++ b/packages/studio/core-wasm/src/processor.ts
@@ -81,6 +81,7 @@ class WasmEngineProcessor extends AudioWorkletProcessor {
     #measureLoad: boolean = false // debug.dspLoadMeasurement (TS EngineProcessor.render's measureLoad)
     #perfWriteIndex: int = 0
     #playbackTimestamp: ppqn = 0.0 // this is where we start playing again (after paused)
+    #wasRecording: boolean = false
 
     constructor({processorOptions}: {processorOptions: EngineProcessorAttachment} & AudioNodeOptions) {
         super()
@@ -102,6 +103,9 @@ class WasmEngineProcessor extends AudioWorkletProcessor {
                 }
                 switchMarkerState(state: Nullable<[UUID.Bytes, int]>): void {
                     dispatcher.dispatchAndForget(this.switchMarkerState, state)
+                }
+                recordingStarted(contextTime: number, position: ppqn): void {
+                    dispatcher.dispatchAndForget(this.recordingStarted, contextTime, position)
                 }
                 ready() {dispatcher.dispatchAndForget(this.ready)}
             })
@@ -337,6 +341,7 @@ class WasmEngineProcessor extends AudioWorkletProcessor {
             }
         }
         engine.render()
+        this.#announceRecordingStart(engine)
         if (monitoring.length > 0 && monitorOutput !== undefined) {
             const outputPtr = engine.monitor_output_ptr()
             const staged = new Float32Array(this.#memory.buffer, outputPtr, 8 * RenderQuantum)
@@ -374,6 +379,20 @@ class WasmEngineProcessor extends AudioWorkletProcessor {
         this.#drainClipChanges()
         this.#drainMarkerChanges()
         this.#midi.drain(engine, this.#memory)
+    }
+
+    // One-shot per recording, on the rising edge of the transport's recording flag as rendered this quantum.
+    // `currentTime` is the START of the quantum in an AudioWorkletGlobalScope, while the position in the
+    // state buffer is the one reached after rendering it: report the quantum END so both describe the same
+    // instant. Read straight from the engine state, not the sync packet, whose populate callback only runs
+    // when the main thread has consumed the previous packet.
+    #announceRecordingStart(engine: EngineExports): void {
+        const view = new DataView(this.#memory.buffer, engine.engine_state_ptr(), engine.engine_state_len())
+        const isRecording = view.getUint8(18) === 1
+        if (isRecording && !this.#wasRecording) {
+            this.#engineToClient.recordingStarted(currentTime + RenderQuantum / sampleRate, view.getFloat32(0))
+        }
+        this.#wasRecording = isRecording
     }
 
     // Forward the engine's queued clip transitions to the client (TS `clipSequencing.changes()` +

--- a/packages/studio/core-wasm/src/processor.ts
+++ b/packages/studio/core-wasm/src/processor.ts
@@ -32,6 +32,7 @@ import {PeakBroadcaster} from "../../core-processors/src/PeakBroadcaster"
 import {GonioCapture, LoudnessMeter, StereoAnalyser} from "./analysis-dsp"
 import {EngineExports} from "./engine-exports"
 import {WasmMidiDrain} from "./midi-drain"
+import {RecordingStartEdge} from "./recording-start-edge"
 import {describeEngineTrap, drainResourceRequests, instantiateWasmEngine} from "./boot"
 import {
     WASM_ENGINE_PROCESSOR_NAME,
@@ -81,7 +82,7 @@ class WasmEngineProcessor extends AudioWorkletProcessor {
     #measureLoad: boolean = false // debug.dspLoadMeasurement (TS EngineProcessor.render's measureLoad)
     #perfWriteIndex: int = 0
     #playbackTimestamp: ppqn = 0.0 // this is where we start playing again (after paused)
-    #wasRecording: boolean = false
+    readonly #recordingStartEdge: RecordingStartEdge = new RecordingStartEdge()
 
     constructor({processorOptions}: {processorOptions: EngineProcessorAttachment} & AudioNodeOptions) {
         super()
@@ -200,6 +201,7 @@ class WasmEngineProcessor extends AudioWorkletProcessor {
                 stopRecording: (): void => this.#guarded(() => {
                     this.#transporting = false
                     engine.stop_recording()
+                    this.#recordingStartEdge.reset()
                 }),
                 queryLoadingComplete: (): Promise<boolean> =>
                     Promise.all(this.#pendingResources).then(() => true),
@@ -381,18 +383,17 @@ class WasmEngineProcessor extends AudioWorkletProcessor {
         this.#midi.drain(engine, this.#memory)
     }
 
-    // One-shot per recording, on the rising edge of the transport's recording flag as rendered this quantum.
+    // One-shot per recording, on the rising edge of the transport's recording flag as rendered this quantum
+    // (the stop command paths reset the edge, since the state buffer only changes in `render`).
     // `currentTime` is the START of the quantum in an AudioWorkletGlobalScope, while the position in the
     // state buffer is the one reached after rendering it: report the quantum END so both describe the same
     // instant. Read straight from the engine state, not the sync packet, whose populate callback only runs
     // when the main thread has consumed the previous packet.
     #announceRecordingStart(engine: EngineExports): void {
         const view = new DataView(this.#memory.buffer, engine.engine_state_ptr(), engine.engine_state_len())
-        const isRecording = view.getUint8(18) === 1
-        if (isRecording && !this.#wasRecording) {
+        if (this.#recordingStartEdge.observe(view.getUint8(18) === 1)) {
             this.#engineToClient.recordingStarted(currentTime + RenderQuantum / sampleRate, view.getFloat32(0))
         }
-        this.#wasRecording = isRecording
     }
 
     // Forward the engine's queued clip transitions to the client (TS `clipSequencing.changes()` +
@@ -468,6 +469,7 @@ class WasmEngineProcessor extends AudioWorkletProcessor {
         const wasRecording = view.getUint8(17) === 1 || view.getUint8(18) === 1
         this.#transporting = false
         this.#engine.pause()
+        this.#recordingStartEdge.reset()
         if (wasRecording) {
             // TS `#stop`: leaving a recording returns the playhead to where playback started (or 0).
             this.#engine.set_position(this.#preferences.settings.playback.timestampEnabled ? this.#playbackTimestamp : 0.0)

--- a/packages/studio/core-wasm/src/recording-start-edge.ts
+++ b/packages/studio/core-wasm/src/recording-start-edge.ts
@@ -1,0 +1,18 @@
+// Detects the start of a recording from the transport's recording flag as the engine state carries it
+// after each render. The engine serializes the flag only in `render`, so a command that ends the
+// recording followed by one that starts the next, both handled before the next quantum, leaves the flag
+// at 1 across two consecutive reads and the new start has no falling edge to follow. The command paths
+// that end a recording call `reset` so the next quantum that reads the flag counts as a start.
+export class RecordingStartEdge {
+    #wasRecording: boolean = false
+
+    // True once per recording: on the first `true` since the last `false` or `reset`.
+    observe(isRecording: boolean): boolean {
+        const started = isRecording && !this.#wasRecording
+        this.#wasRecording = isRecording
+        return started
+    }
+
+    // The recording ended by command (stop, stopRecording) rather than in a render.
+    reset(): void {this.#wasRecording = false}
+}

--- a/packages/studio/core-wasm/src/worklet.d.ts
+++ b/packages/studio/core-wasm/src/worklet.d.ts
@@ -15,3 +15,4 @@ declare function registerProcessor(
 ): void
 
 declare const sampleRate: number
+declare const currentTime: number

--- a/packages/studio/core-wasm/test/recording-start-edge.test.ts
+++ b/packages/studio/core-wasm/test/recording-start-edge.test.ts
@@ -1,0 +1,32 @@
+// The processor announces `recordingStarted` once per recording from the flag the engine state carries
+// after each render (see src/recording-start-edge.ts). The flag itself only changes in `render`, so a
+// recording ended by command must reset the edge, or the next recording started before the following
+// quantum reads as a continuation.
+import {describe, expect, it} from "vitest"
+import {RecordingStartEdge} from "../src/recording-start-edge"
+
+describe("RecordingStartEdge", () => {
+    it("announces once on the rising edge and again after a falling edge", () => {
+        const edge = new RecordingStartEdge()
+        expect(edge.observe(false)).toBe(false)
+        expect(edge.observe(true), "the rising edge").toBe(true)
+        expect(edge.observe(true), "still recording").toBe(false)
+        expect(edge.observe(false)).toBe(false)
+        expect(edge.observe(true), "the next recording").toBe(true)
+    })
+
+    it("announces after a reset although the flag never read false in between", () => {
+        const edge = new RecordingStartEdge()
+        expect(edge.observe(true)).toBe(true)
+        edge.reset()
+        expect(edge.observe(true), "a start following a stop command counts as new").toBe(true)
+        expect(edge.observe(true)).toBe(false)
+    })
+
+    it("a reset while not recording changes nothing", () => {
+        const edge = new RecordingStartEdge()
+        edge.reset()
+        expect(edge.observe(false)).toBe(false)
+        expect(edge.observe(true)).toBe(true)
+    })
+})

--- a/packages/studio/core-wasm/test/recording-state.test.ts
+++ b/packages/studio/core-wasm/test/recording-state.test.ts
@@ -8,6 +8,7 @@ import {ApparatDeviceBox, AudioUnitBox, CaptureMidiBox, NoteEventBox, NoteEventC
 import {ProjectSkeleton, ScriptCompiler, TrackType} from "@opendaw/studio-adapters"
 import {loadFullEngine} from "./helpers/load-full-engine"
 import {connectSyncToEngine} from "./helpers/connect-sync"
+import {RecordingStartEdge} from "../src/recording-start-edge"
 
 const SYNTH = `class Processor {
     voices = []
@@ -132,6 +133,56 @@ describe("recording state machine", () => {
         engine.pause()
         engine.render()
         expect(readState(engine, memory).isRecording, "pause ends recording (TS TimeInfo.pause)").toBe(false)
+    }, 60000)
+
+    it("a restart handled between two renders is announced only when the stop reset the edge", async () => {
+        const {source} = build()
+        const {engine, memory} = await loadFullEngine()
+        const sync = connectSyncToEngine(engine, memory, source)
+        await sync.settle(); engine.bind(); await sync.settle()
+        engine.set_metronome_enabled(0)
+        // The processor's per-quantum announcement: render, then read the recording flag from the state.
+        // Two edges observe the same flag: `edge` is reset by the stop commands as the worklet's handlers
+        // do, `unreset` never is (the render-only edge), so the two must diverge exactly at the restart.
+        const edge = new RecordingStartEdge()
+        const unreset = new RecordingStartEdge()
+        const starts: Array<number> = []
+        const unresetStarts: Array<number> = []
+        const render = (): State => {
+            engine.render()
+            const state = readState(engine, memory)
+            if (edge.observe(state.isRecording)) {starts.push(state.position)}
+            if (unreset.observe(state.isRecording)) {unresetStarts.push(state.position)}
+            return state
+        }
+        engine.prepare_recording_state(0, 1.0)
+        for (let quantum = 0; quantum < 8; quantum++) {render()}
+        expect(starts.length, "the first start").toBe(1)
+        expect(unresetStarts.length, "the first start needs no reset").toBe(1)
+        // Commands run between renders, and only render writes the state: the flag reads 1 on the quantum
+        // before the stop and on the quantum after the restart, so nothing but the reset marks the gap.
+        expect(readState(engine, memory).isRecording, "recording before the stop").toBe(true)
+        engine.stop_recording()
+        edge.reset() // the worklet's stopRecording command
+        engine.prepare_recording_state(0, 1.0)
+        const restarted = render()
+        expect(restarted.isRecording, "recording again on the next render").toBe(true)
+        expect(starts.length, "the restart is announced").toBe(2)
+        expect(starts[1], "with the position the restart began at").toBeGreaterThan(starts[0])
+        expect(unresetStarts.length, "without the reset the restart passes unannounced").toBe(1)
+        // The same through the transport stop command (pause), which ends a recording as well.
+        for (let quantum = 0; quantum < 8; quantum++) {render()}
+        engine.pause()
+        edge.reset() // the worklet's stop command
+        engine.prepare_recording_state(0, 1.0)
+        expect(render().isRecording).toBe(true)
+        expect(starts.length, "the start after a pause is announced").toBe(3)
+        expect(starts[2]).toBeGreaterThan(starts[1])
+        expect(unresetStarts.length, "the render-only edge misses this one too").toBe(1)
+        // Without any command in between, a recording that keeps running announces nothing more.
+        for (let quantum = 0; quantum < 8; quantum++) {render()}
+        expect(starts.length).toBe(3)
+        expect(unresetStarts.length).toBe(1)
     }, 60000)
 
     it("an ignored note region emits nothing until the recording ends", async () => {

--- a/packages/studio/core-wasm/test/recording-state.test.ts
+++ b/packages/studio/core-wasm/test/recording-state.test.ts
@@ -139,50 +139,54 @@ describe("recording state machine", () => {
         const {source} = build()
         const {engine, memory} = await loadFullEngine()
         const sync = connectSyncToEngine(engine, memory, source)
-        await sync.settle(); engine.bind(); await sync.settle()
-        engine.set_metronome_enabled(0)
-        // The processor's per-quantum announcement: render, then read the recording flag from the state.
-        // Two edges observe the same flag: `edge` is reset by the stop commands as the worklet's handlers
-        // do, `unreset` never is (the render-only edge), so the two must diverge exactly at the restart.
-        const edge = new RecordingStartEdge()
-        const unreset = new RecordingStartEdge()
-        const starts: Array<number> = []
-        const unresetStarts: Array<number> = []
-        const render = (): State => {
-            engine.render()
-            const state = readState(engine, memory)
-            if (edge.observe(state.isRecording)) {starts.push(state.position)}
-            if (unreset.observe(state.isRecording)) {unresetStarts.push(state.position)}
-            return state
+        try {
+            await sync.settle(); engine.bind(); await sync.settle()
+            engine.set_metronome_enabled(0)
+            // The processor's per-quantum announcement: render, then read the recording flag from the state.
+            // Two edges observe the same flag: `edge` is reset by the stop commands as the worklet's handlers
+            // do, `unreset` never is (the render-only edge), so the two must diverge exactly at the restart.
+            const edge = new RecordingStartEdge()
+            const unreset = new RecordingStartEdge()
+            const starts: Array<number> = []
+            const unresetStarts: Array<number> = []
+            const render = (): State => {
+                engine.render()
+                const state = readState(engine, memory)
+                if (edge.observe(state.isRecording)) {starts.push(state.position)}
+                if (unreset.observe(state.isRecording)) {unresetStarts.push(state.position)}
+                return state
+            }
+            engine.prepare_recording_state(0, 1.0)
+            for (let quantum = 0; quantum < 8; quantum++) {render()}
+            expect(starts.length, "the first start").toBe(1)
+            expect(unresetStarts.length, "the first start needs no reset").toBe(1)
+            // Commands run between renders, and only render writes the state: the flag reads 1 on the quantum
+            // before the stop and on the quantum after the restart, so nothing but the reset marks the gap.
+            expect(readState(engine, memory).isRecording, "recording before the stop").toBe(true)
+            engine.stop_recording()
+            edge.reset() // the worklet's stopRecording command
+            engine.prepare_recording_state(0, 1.0)
+            const restarted = render()
+            expect(restarted.isRecording, "recording again on the next render").toBe(true)
+            expect(starts.length, "the restart is announced").toBe(2)
+            expect(starts[1], "with the position the restart began at").toBeGreaterThan(starts[0])
+            expect(unresetStarts.length, "without the reset the restart passes unannounced").toBe(1)
+            // The same through the transport stop command (pause), which ends a recording as well.
+            for (let quantum = 0; quantum < 8; quantum++) {render()}
+            engine.pause()
+            edge.reset() // the worklet's stop command
+            engine.prepare_recording_state(0, 1.0)
+            expect(render().isRecording).toBe(true)
+            expect(starts.length, "the start after a pause is announced").toBe(3)
+            expect(starts[2]).toBeGreaterThan(starts[1])
+            expect(unresetStarts.length, "the render-only edge misses this one too").toBe(1)
+            // Without any command in between, a recording that keeps running announces nothing more.
+            for (let quantum = 0; quantum < 8; quantum++) {render()}
+            expect(starts.length).toBe(3)
+            expect(unresetStarts.length).toBe(1)
+        } finally {
+            sync.close()
         }
-        engine.prepare_recording_state(0, 1.0)
-        for (let quantum = 0; quantum < 8; quantum++) {render()}
-        expect(starts.length, "the first start").toBe(1)
-        expect(unresetStarts.length, "the first start needs no reset").toBe(1)
-        // Commands run between renders, and only render writes the state: the flag reads 1 on the quantum
-        // before the stop and on the quantum after the restart, so nothing but the reset marks the gap.
-        expect(readState(engine, memory).isRecording, "recording before the stop").toBe(true)
-        engine.stop_recording()
-        edge.reset() // the worklet's stopRecording command
-        engine.prepare_recording_state(0, 1.0)
-        const restarted = render()
-        expect(restarted.isRecording, "recording again on the next render").toBe(true)
-        expect(starts.length, "the restart is announced").toBe(2)
-        expect(starts[1], "with the position the restart began at").toBeGreaterThan(starts[0])
-        expect(unresetStarts.length, "without the reset the restart passes unannounced").toBe(1)
-        // The same through the transport stop command (pause), which ends a recording as well.
-        for (let quantum = 0; quantum < 8; quantum++) {render()}
-        engine.pause()
-        edge.reset() // the worklet's stop command
-        engine.prepare_recording_state(0, 1.0)
-        expect(render().isRecording).toBe(true)
-        expect(starts.length, "the start after a pause is announced").toBe(3)
-        expect(starts[2]).toBeGreaterThan(starts[1])
-        expect(unresetStarts.length, "the render-only edge misses this one too").toBe(1)
-        // Without any command in between, a recording that keeps running announces nothing more.
-        for (let quantum = 0; quantum < 8; quantum++) {render()}
-        expect(starts.length).toBe(3)
-        expect(unresetStarts.length).toBe(1)
     }, 60000)
 
     it("an ignored note region emits nothing until the recording ends", async () => {

--- a/packages/studio/core/src/Engine.ts
+++ b/packages/studio/core/src/Engine.ts
@@ -16,7 +16,7 @@ import {Project} from "./project"
 // Where and when the transport began recording, as reported by the engine from the audio thread:
 // `position` is the playhead after the render quantum in which recording began and `contextTime` is
 // the context clock at the end of that quantum. Empty until the engine reports it; cleared when a
-// recording is prepared.
+// recording is prepared, and a report for an earlier recording that arrives after that is dropped.
 export type RecordingStart = {readonly contextTime: number, readonly position: ppqn}
 
 export interface Engine extends Terminable {

--- a/packages/studio/core/src/Engine.ts
+++ b/packages/studio/core/src/Engine.ts
@@ -1,7 +1,23 @@
-import {int, Nullable, ObservableValue, Observer, Procedure, Subscription, Terminable, UUID} from "@opendaw/lib-std"
+import {
+    int,
+    Nullable,
+    ObservableOption,
+    ObservableValue,
+    Observer,
+    Procedure,
+    Subscription,
+    Terminable,
+    UUID
+} from "@opendaw/lib-std"
 import {AudioData, bpm, ppqn} from "@opendaw/lib-dsp"
 import {ClipNotification, EnginePreferences, NoteSignal} from "@opendaw/studio-adapters"
 import {Project} from "./project"
+
+// Where and when the transport began recording, as reported by the engine from the audio thread:
+// `position` is the playhead after the render quantum in which recording began and `contextTime` is
+// the context clock at the end of that quantum. Empty until the engine reports it; cleared when a
+// recording is prepared.
+export type RecordingStart = {readonly contextTime: number, readonly position: ppqn}
 
 export interface Engine extends Terminable {
     play(): void
@@ -31,6 +47,7 @@ export interface Engine extends Terminable {
     unregisterMonitoringSource(uuid: UUID.Bytes): void
 
     get position(): ObservableValue<ppqn>
+    get recordingStart(): ObservableOption<RecordingStart>
     get bpm(): ObservableValue<bpm>
     get isPlaying(): ObservableValue<boolean>
     get isRecording(): ObservableValue<boolean>

--- a/packages/studio/core/src/EngineFacade.ts
+++ b/packages/studio/core/src/EngineFacade.ts
@@ -1,7 +1,9 @@
 import {
     DefaultObservableValue,
     int,
+    MutableObservableOption,
     Nullable,
+    ObservableOption,
     ObservableValue,
     Observer,
     Option,
@@ -20,7 +22,7 @@ import {
     PreferencesFacade
 } from "@opendaw/studio-adapters"
 import {AudioContexts} from "./AudioContexts"
-import {Engine} from "./Engine"
+import {Engine, RecordingStart} from "./Engine"
 import {EngineWorklet} from "./EngineWorklet"
 import {Project} from "./project"
 import {Preferences} from "@opendaw/lib-fusion"
@@ -31,6 +33,7 @@ export class EngineFacade implements Engine {
     readonly #playbackTimestamp: DefaultObservableValue<ppqn> = new DefaultObservableValue(0.0)
     readonly #countInBeatsRemaining: DefaultObservableValue<int> = new DefaultObservableValue(0)
     readonly #position: DefaultObservableValue<ppqn> = new DefaultObservableValue(0.0)
+    readonly #recordingStart: MutableObservableOption<RecordingStart> = new MutableObservableOption()
     readonly #bpm: DefaultObservableValue<bpm> = new DefaultObservableValue(12.0)
     readonly #isPlaying: DefaultObservableValue<boolean> = new DefaultObservableValue(false)
     readonly #isRecording: DefaultObservableValue<boolean> = new DefaultObservableValue(false)
@@ -54,6 +57,10 @@ export class EngineFacade implements Engine {
             worklet.playbackTimestamp.catchupAndSubscribe(owner => this.#playbackTimestamp.setValue(owner.getValue())),
             worklet.countInBeatsRemaining.catchupAndSubscribe(owner => this.#countInBeatsRemaining.setValue(owner.getValue())),
             worklet.position.catchupAndSubscribe(owner => this.#position.setValue(owner.getValue())),
+            worklet.recordingStart.catchupAndSubscribe(option => option.match({
+                none: () => this.#recordingStart.clear(),
+                some: start => this.#recordingStart.wrap(start)
+            })),
             worklet.bpm.catchupAndSubscribe(owner => this.#bpm.setValue(owner.getValue())),
             worklet.isPlaying.catchupAndSubscribe(owner => this.#isPlaying.setValue(owner.getValue())),
             worklet.isRecording.catchupAndSubscribe(owner => this.#isRecording.setValue(owner.getValue())),
@@ -88,6 +95,7 @@ export class EngineFacade implements Engine {
     stopRecording(): void {this.#worklet.ifSome(worklet => worklet.stopRecording())}
 
     get position(): ObservableValue<ppqn> {return this.#position}
+    get recordingStart(): ObservableOption<RecordingStart> {return this.#recordingStart}
     get bpm(): ObservableValue<bpm> {return this.#bpm}
     get isPlaying(): ObservableValue<boolean> {return this.#isPlaying}
     get isRecording(): ObservableValue<boolean> {return this.#isRecording}

--- a/packages/studio/core/src/EngineWorklet.ts
+++ b/packages/studio/core/src/EngineWorklet.ts
@@ -69,6 +69,7 @@ export class EngineWorklet extends AudioWorkletNode implements Engine {
         new DefaultObservableValue<Nullable<[UUID.Bytes, int]>>(null)
     readonly #cpuLoad: DefaultObservableValue<number> = new DefaultObservableValue(0)
     readonly #recordingStart: MutableObservableOption<RecordingStart> = new MutableObservableOption()
+    #recordingGeneration: int = 0
     readonly #controlFlags: Int32Array<SharedArrayBuffer>
     readonly #notifyClipNotification: Notifier<ClipNotification>
     readonly #notifyNoteSignals: Notifier<NoteSignal>
@@ -140,8 +141,8 @@ export class EngineWorklet extends AudioWorkletNode implements Engine {
                     play(): void {dispatcher.dispatchAndForget(this.play)}
                     stop(reset: boolean): void {dispatcher.dispatchAndForget(this.stop, reset)}
                     setPosition(position: number): void {dispatcher.dispatchAndForget(this.setPosition, position)}
-                    prepareRecordingState(countIn: boolean) {
-                        dispatcher.dispatchAndForget(this.prepareRecordingState, countIn)
+                    prepareRecordingState(countIn: boolean, generation: int) {
+                        dispatcher.dispatchAndForget(this.prepareRecordingState, countIn, generation)
                     }
                     stopRecording() {dispatcher.dispatchAndForget(this.stopRecording)}
                     queryLoadingComplete(): Promise<boolean> {
@@ -242,8 +243,11 @@ export class EngineWorklet extends AudioWorkletNode implements Engine {
                     this.#notifyClipNotification.notify({type: "sequencing", changes})
                 },
                 switchMarkerState: (state: Nullable<[UUID.Bytes, int]>): void => this.#markerState.setValue(state),
-                recordingStarted: (contextTime: number, position: ppqn): void =>
+                recordingStarted: (contextTime: number, position: ppqn, generation: int): void => {
+                    // a report for an earlier recording, delivered after the next one was prepared
+                    if (generation !== this.#recordingGeneration) {return}
                     this.#recordingStart.wrap({contextTime, position})
+                }
             } satisfies EngineToClient
         )
         this.#preferences = this.#terminator.own(new PreferencesHost<EngineSettings>(EngineSettingsSchema.parse({})))
@@ -262,8 +266,9 @@ export class EngineWorklet extends AudioWorkletNode implements Engine {
     stop(reset: boolean = false): void {this.#commands.stop(reset)}
     setPosition(position: ppqn): void {this.#commands.setPosition(position)}
     prepareRecordingState(countIn: boolean): void {
+        this.#recordingGeneration++
         this.#recordingStart.clear() // the engine reports the new start once the transport flips
-        this.#commands.prepareRecordingState(countIn)
+        this.#commands.prepareRecordingState(countIn, this.#recordingGeneration)
     }
     stopRecording(): void {this.#commands.stopRecording()}
     panic(): void {this.#commands.panic()}

--- a/packages/studio/core/src/EngineWorklet.ts
+++ b/packages/studio/core/src/EngineWorklet.ts
@@ -4,9 +4,11 @@ import {
     int,
     isDefined,
     isNull,
+    MutableObservableOption,
     MutableObservableValue,
     Notifier,
     Nullable,
+    ObservableOption,
     ObservableValue,
     Observer,
     Option,
@@ -39,7 +41,7 @@ import {
 import {SyncSource} from "@opendaw/lib-box"
 import {AnimationFrame} from "@opendaw/lib-dom"
 import {BoxIO} from "@opendaw/studio-boxes"
-import {Engine} from "./Engine"
+import {Engine, RecordingStart} from "./Engine"
 import {EngineVariant, EngineWorkletVariant, FrozenAudioWriter} from "./EngineVariant"
 import {MonitoringRouter} from "./MonitoringRouter"
 import {Project} from "./project"
@@ -66,6 +68,7 @@ export class EngineWorklet extends AudioWorkletNode implements Engine {
     readonly #markerState: DefaultObservableValue<Nullable<[UUID.Bytes, int]>> =
         new DefaultObservableValue<Nullable<[UUID.Bytes, int]>>(null)
     readonly #cpuLoad: DefaultObservableValue<number> = new DefaultObservableValue(0)
+    readonly #recordingStart: MutableObservableOption<RecordingStart> = new MutableObservableOption()
     readonly #controlFlags: Int32Array<SharedArrayBuffer>
     readonly #notifyClipNotification: Notifier<ClipNotification>
     readonly #notifyNoteSignals: Notifier<NoteSignal>
@@ -238,7 +241,9 @@ export class EngineWorklet extends AudioWorkletNode implements Engine {
                     changes.started.forEach(uuid => this.#playingClips.push(uuid))
                     this.#notifyClipNotification.notify({type: "sequencing", changes})
                 },
-                switchMarkerState: (state: Nullable<[UUID.Bytes, int]>): void => this.#markerState.setValue(state)
+                switchMarkerState: (state: Nullable<[UUID.Bytes, int]>): void => this.#markerState.setValue(state),
+                recordingStarted: (contextTime: number, position: ppqn): void =>
+                    this.#recordingStart.wrap({contextTime, position})
             } satisfies EngineToClient
         )
         this.#preferences = this.#terminator.own(new PreferencesHost<EngineSettings>(EngineSettingsSchema.parse({})))
@@ -256,7 +261,10 @@ export class EngineWorklet extends AudioWorkletNode implements Engine {
     }
     stop(reset: boolean = false): void {this.#commands.stop(reset)}
     setPosition(position: ppqn): void {this.#commands.setPosition(position)}
-    prepareRecordingState(countIn: boolean): void {this.#commands.prepareRecordingState(countIn)}
+    prepareRecordingState(countIn: boolean): void {
+        this.#recordingStart.clear() // the engine reports the new start once the transport flips
+        this.#commands.prepareRecordingState(countIn)
+    }
     stopRecording(): void {this.#commands.stopRecording()}
     panic(): void {this.#commands.panic()}
     sleep(): void {
@@ -279,6 +287,7 @@ export class EngineWorklet extends AudioWorkletNode implements Engine {
     get isCountingIn(): ObservableValue<boolean> {return this.#isCountingIn}
     get countInBeatsRemaining(): ObservableValue<number> {return this.#countInBeatsRemaining}
     get position(): ObservableValue<ppqn> {return this.#position}
+    get recordingStart(): ObservableOption<RecordingStart> {return this.#recordingStart}
     get bpm(): ObservableValue<bpm> {return this.#bpm}
     get playbackTimestamp(): MutableObservableValue<number> {return this.#playbackTimestamp}
     get markerState(): ObservableValue<Nullable<[UUID.Bytes, int]>> {return this.#markerState}

--- a/packages/studio/core/src/OfflineEngineRenderer.ts
+++ b/packages/studio/core/src/OfflineEngineRenderer.ts
@@ -131,7 +131,7 @@ export class OfflineEngineRenderer {
                 play(): void { dispatcher.dispatchAndForget(this.play) }
                 stop(reset: boolean): void { dispatcher.dispatchAndForget(this.stop, reset) }
                 setPosition(position: ppqn): void { dispatcher.dispatchAndForget(this.setPosition, position) }
-                prepareRecordingState(countIn: boolean): void { dispatcher.dispatchAndForget(this.prepareRecordingState, countIn) }
+                prepareRecordingState(countIn: boolean, generation: int): void { dispatcher.dispatchAndForget(this.prepareRecordingState, countIn, generation) }
                 stopRecording(): void { dispatcher.dispatchAndForget(this.stopRecording) }
                 queryLoadingComplete(): Promise<boolean> { return dispatcher.dispatchAndReturn(this.queryLoadingComplete) }
                 panic(): void { dispatcher.dispatchAndForget(this.panic) }

--- a/packages/studio/core/src/OfflineEngineRenderer.ts
+++ b/packages/studio/core/src/OfflineEngineRenderer.ts
@@ -119,6 +119,7 @@ export class OfflineEngineRenderer {
             },
             notifyClipSequenceChanges: (): void => {},
             switchMarkerState: (): void => {},
+            recordingStarted: (): void => {},
             deviceMessage: (uuid: string, message: string): void => {
                 console.warn(`OFFLINE-ENGINE device(${uuid}): ${message}`)
             }

--- a/packages/studio/core/src/RecordingWorklet.test.ts
+++ b/packages/studio/core/src/RecordingWorklet.test.ts
@@ -1,0 +1,45 @@
+import {describe, expect, it} from "vitest"
+import {isDefined} from "@opendaw/lib-std"
+import {RenderQuantum} from "@opendaw/lib-dsp"
+
+if (!isDefined(Reflect.get(globalThis, "AudioWorkletNode"))) {
+    Reflect.set(globalThis, "AudioWorkletNode", class {})
+}
+
+// Chunks carry a ramp so every frame identifies its own index: channel c of chunk k holds
+// frame index * 1 + c * 1000 for the frames it covers.
+const chunks = (count: number, channels: number): ReadonlyArray<ReadonlyArray<Float32Array>> =>
+    Array.from({length: count}, (_, k) => Array.from({length: channels}, (_, c) =>
+        Float32Array.from({length: RenderQuantum}, (_, i) => k * RenderQuantum + i + c * 1000)))
+
+describe("recordedFrames", () => {
+    it("keeps the head and drops the overshoot when the limit falls inside a chunk", async () => {
+        const {recordedFrames} = await import("./RecordingWorklet")
+        const numFrames = 3 * RenderQuantum + 17
+        const planes = recordedFrames(chunks(6, 2), numFrames)
+        expect(planes.length).toBe(2)
+        for (const [c, plane] of planes.entries()) {
+            expect(plane.length).toBe(numFrames)
+            expect(plane[0]).toBe(c * 1000)
+            expect(plane[RenderQuantum]).toBe(RenderQuantum + c * 1000)
+            expect(plane[numFrames - 1]).toBe(numFrames - 1 + c * 1000)
+        }
+    })
+
+    it("returns every frame when the limit is exactly the recorded length", async () => {
+        const {recordedFrames} = await import("./RecordingWorklet")
+        const numFrames = 4 * RenderQuantum
+        const [plane] = recordedFrames(chunks(4, 1), numFrames)
+        expect(plane.length).toBe(numFrames)
+        expect(plane[0]).toBe(0)
+        expect(plane[numFrames - 1]).toBe(numFrames - 1)
+    })
+
+    it("keeps the head when the limit ends on a chunk boundary", async () => {
+        const {recordedFrames} = await import("./RecordingWorklet")
+        const numFrames = 2 * RenderQuantum
+        const [plane] = recordedFrames(chunks(5, 1), numFrames)
+        expect(plane.length).toBe(numFrames)
+        expect(plane[numFrames - 1]).toBe(numFrames - 1)
+    })
+})

--- a/packages/studio/core/src/RecordingWorklet.test.ts
+++ b/packages/studio/core/src/RecordingWorklet.test.ts
@@ -6,11 +6,12 @@ if (!isDefined(Reflect.get(globalThis, "AudioWorkletNode"))) {
     Reflect.set(globalThis, "AudioWorkletNode", class {})
 }
 
-// Chunks carry a ramp so every frame identifies its own index: channel c of chunk k holds
-// frame index * 1 + c * 1000 for the frames it covers.
+// Chunks carry a ramp so every frame identifies its own index: a channel of a chunk holds
+// frame index + channel index * 1000 for the frames it covers.
 const chunks = (count: number, channels: number): ReadonlyArray<ReadonlyArray<Float32Array>> =>
-    Array.from({length: count}, (_, k) => Array.from({length: channels}, (_, c) =>
-        Float32Array.from({length: RenderQuantum}, (_, i) => k * RenderQuantum + i + c * 1000)))
+    Array.from({length: count}, (_, chunkIndex) => Array.from({length: channels}, (_, channelIndex) =>
+        Float32Array.from({length: RenderQuantum},
+            (_, frameIndex) => chunkIndex * RenderQuantum + frameIndex + channelIndex * 1000)))
 
 describe("recordedFrames", () => {
     it("keeps the head and drops the overshoot when the limit falls inside a chunk", async () => {
@@ -18,11 +19,11 @@ describe("recordedFrames", () => {
         const numFrames = 3 * RenderQuantum + 17
         const planes = recordedFrames(chunks(6, 2), numFrames)
         expect(planes.length).toBe(2)
-        for (const [c, plane] of planes.entries()) {
+        for (const [channelIndex, plane] of planes.entries()) {
             expect(plane.length).toBe(numFrames)
-            expect(plane[0]).toBe(c * 1000)
-            expect(plane[RenderQuantum]).toBe(RenderQuantum + c * 1000)
-            expect(plane[numFrames - 1]).toBe(numFrames - 1 + c * 1000)
+            expect(plane[0]).toBe(channelIndex * 1000)
+            expect(plane[RenderQuantum]).toBe(RenderQuantum + channelIndex * 1000)
+            expect(plane[numFrames - 1]).toBe(numFrames - 1 + channelIndex * 1000)
         }
     })
 

--- a/packages/studio/core/src/RecordingWorklet.ts
+++ b/packages/studio/core/src/RecordingWorklet.ts
@@ -17,6 +17,16 @@ import {RenderQuantum} from "./RenderQuantum"
 import {PeaksWriter} from "./PeaksWriter"
 import {SampleService} from "./samples"
 
+/**
+ * The first `numFrames` frames of the recorded chunks, as one plane per channel. The ring delivers
+ * whole chunks, so the recording can run past the frame count the takes reference: the HEAD is kept
+ * (regions address the buffer from frame 0 through `waveformOffset`) and the overshoot is dropped
+ * at the tail. `numFrames` must not exceed the frames the chunks hold.
+ */
+export const recordedFrames = (chunks: ReadonlyArray<ReadonlyArray<Float32Array>>,
+                               numFrames: int): ReadonlyArray<Float32Array> =>
+    mergeChunkPlanes(chunks.slice(0, Math.ceil(numFrames / RenderQuantum)), RenderQuantum, numFrames)
+
 export class RecordingWorklet extends AudioWorkletNode implements Terminable, SampleLoader {
     readonly #terminator: Terminator = new Terminator()
 
@@ -29,6 +39,7 @@ export class RecordingWorklet extends AudioWorkletNode implements Terminable, Sa
 
     #data: Option<AudioData> = Option.None
     #peaks: Option<Peaks> = Option.None
+    #firstQuantumTime: Option<number> = Option.None
     #isRecording: boolean = true
     #limitSamples: int = Number.POSITIVE_INFINITY
     #state: SampleLoaderState = {type: "record"}
@@ -46,6 +57,12 @@ export class RecordingWorklet extends AudioWorkletNode implements Terminable, Sa
 
         this.#peakWriter = new PeaksWriter(config.numberOfChannels)
         this.#peaks = Option.wrap(this.#peakWriter)
+        this.port.addEventListener("message", ({data}: MessageEvent) => {
+            if (data?.type === "first-quantum" && typeof data.contextTime === "number") {
+                this.#firstQuantumTime = Option.wrap(data.contextTime)
+            }
+        })
+        this.port.start()
         this.#output = []
         this.#notifier = new Notifier<SampleLoaderState>()
         this.#reader = RingBuffer.reader(config, array => {
@@ -75,6 +92,13 @@ export class RecordingWorklet extends AudioWorkletNode implements Terminable, Sa
     setFillLength(value: int): void {this.#peakWriter.numFrames = value}
 
     get numberOfFrames(): int {return this.#output.length * RenderQuantum}
+    /**
+     * Context time of the buffer's first frame, reported by the processor from the audio thread.
+     * Empty until the announcement arrives over the port. Frame `(t - firstQuantumTime) * sampleRate`
+     * of the buffer was captured at context time `t`; `numberOfFrames` cannot say that, because it
+     * counts chunks as the ring reader delivers them.
+     */
+    get firstQuantumTime(): Option<number> {return this.#firstQuantumTime}
     // A take in progress is not a stored sample yet, so it has no metadata to report. It acquires some when
     // `#save` hands it to `SampleService.importRecording`, and from then on a `DefaultSampleLoader` serves it.
     get meta(): Option<SampleMetaData> {return Option.None}
@@ -105,8 +129,7 @@ export class RecordingWorklet extends AudioWorkletNode implements Terminable, Sa
         this.#reader.stop()
         if (this.#output.length === 0) {return panic("No recording data available")}
         const totalSamples: int = this.#limitSamples
-        const mergedFrames = mergeChunkPlanes(this.#output, RenderQuantum, this.#output.length * RenderQuantum)
-            .map(frame => frame.slice(-totalSamples))
+        const mergedFrames = recordedFrames(this.#output, totalSamples)
         const audioData = AudioData.create(this.context.sampleRate, totalSamples, this.channelCount)
         mergedFrames.forEach((frame, index) => audioData.frames[index].set(frame))
         this.#data = Option.wrap(audioData)

--- a/packages/studio/core/src/capture/CaptureAudio.test.ts
+++ b/packages/studio/core/src/capture/CaptureAudio.test.ts
@@ -1,0 +1,167 @@
+import {describe, expect, it} from "vitest"
+import {isDefined, Option, UUID} from "@opendaw/lib-std"
+import {ProjectSkeleton} from "@opendaw/studio-adapters"
+import {CaptureAudioBox} from "@opendaw/studio-boxes"
+import type {ProjectEnv} from "../project/ProjectEnv"
+import type {CaptureDevices} from "./CaptureDevices"
+import type {RecordingWorklet} from "../RecordingWorklet"
+
+// A recording is placed from reports the audio thread sends while rendering, so a capture may only be
+// prepared on a running context. These tests drive `prepareRecording` against contexts that are
+// running, that resume on demand, and that stay suspended.
+
+if (!isDefined(Reflect.get(globalThis, "AudioWorkletNode"))) {
+    Reflect.set(globalThis, "AudioWorkletNode", class {})
+}
+
+type FakeNode = {
+    connect: (target: unknown) => void
+    disconnect: (target?: unknown) => void
+    disconnected: Array<unknown>
+    gain: {value: number}
+    pan: {value: number}
+    channelCount: number
+    channelCountMode: string
+}
+
+const createFakeNode = (): FakeNode => ({
+    connect: () => {},
+    disconnect(target?: unknown) {this.disconnected.push(target)},
+    disconnected: new Array<unknown>(),
+    gain: {value: 0},
+    pan: {value: 0},
+    channelCount: 2,
+    channelCountMode: "explicit"
+})
+
+const createFakeStream = () => ({
+    getAudioTracks: () => [{
+        label: "Fake Input",
+        getSettings: () => ({deviceId: "fake-device", channelCount: 2, latency: 0.005}),
+        stop: () => {}
+    }]
+})
+
+// `AudioDevices.requestStream` goes through `navigator.mediaDevices`; nothing else in these tests does.
+const installFakeMediaDevices = () => {
+    Reflect.set(globalThis, "navigator", {
+        mediaDevices: {
+            getUserMedia: async () => createFakeStream(),
+            enumerateDevices: async () => []
+        }
+    })
+}
+
+const createFakeRecordingWorklet = () => ({
+    uuid: UUID.generate(),
+    terminated: false,
+    set bpm(_: number) {},
+    set sampleService(_: unknown) {},
+    terminate(): void {this.terminated = true}
+})
+
+const setup = async ({state = "running", resumesTo = "running"}:
+                     {state?: AudioContextState, resumesTo?: AudioContextState} = {}) => {
+    installFakeMediaDevices()
+    const {Project} = await import("../project/Project")
+    const {CaptureAudio} = await import("./CaptureAudio")
+    const audioContext = {
+        state,
+        outputLatency: 0.020,
+        baseLatency: 0.005,
+        sampleRate: 48_000,
+        resumeCalls: 0,
+        async resume(): Promise<void> {
+            this.resumeCalls++
+            this.state = resumesTo
+        },
+        createGain: () => createFakeNode(),
+        createStereoPanner: () => createFakeNode(),
+        createMediaStreamSource: () => createFakeNode()
+    }
+    const preparedWorklets = new Array<ReturnType<typeof createFakeRecordingWorklet>>()
+    const removedFromSampleManager = new Array<UUID.Bytes>()
+    const env = {
+        audioContext,
+        audioWorklets: {
+            createRecording: () => {
+                const worklet = createFakeRecordingWorklet()
+                preparedWorklets.push(worklet)
+                return worklet as unknown as RecordingWorklet
+            }
+        },
+        sampleManager: {
+            record: () => {},
+            remove: (uuid: UUID.Bytes) => {removedFromSampleManager.push(uuid)}
+        },
+        soundfontManager: undefined, sampleService: undefined, soundfontService: undefined
+    } as unknown as ProjectEnv
+    const skeleton = ProjectSkeleton.empty({createDefaultUser: true, createOutputMaximizer: false})
+    const project = Project.fromSkeleton(env, skeleton)
+    const {primaryAudioUnitBox} = skeleton.mandatoryBoxes
+    const captureBox = project.editing.modify(() => {
+        const box = CaptureAudioBox.create(project.boxGraph, UUID.generate())
+        primaryAudioUnitBox.capture.refer(box) // the box is mandatory-referenced
+        return box
+    }).unwrap()
+    const manager = {project} as unknown as CaptureDevices
+    const capture = new CaptureAudio(manager, primaryAudioUnitBox, captureBox)
+    // The record gain node is the one the audio chain holds; the monitor nodes come from the same factory.
+    const recordGainNode = (): FakeNode => capture.outputNode.unwrap("no audio chain") as unknown as FakeNode
+    return {capture, audioContext, preparedWorklets, removedFromSampleManager, recordGainNode}
+}
+
+describe("CaptureAudio", () => {
+    describe("preparing a recording", () => {
+        it("prepares on a running context", async () => {
+            const {capture, audioContext, preparedWorklets} = await setup()
+            await expect(capture.prepareRecording()).resolves.toBeUndefined()
+            expect(audioContext.resumeCalls).toBe(0)
+            expect(preparedWorklets.length).toBe(1)
+            expect(preparedWorklets[0].terminated).toBe(false)
+        })
+
+        it("resumes a suspended context and prepares once it is running", async () => {
+            const {capture, audioContext, preparedWorklets} = await setup({state: "suspended"})
+            await expect(capture.prepareRecording()).resolves.toBeUndefined()
+            expect(audioContext.resumeCalls).toBe(1)
+            expect(audioContext.state).toBe("running")
+            expect(preparedWorklets.length).toBe(1)
+        })
+
+        it("rejects when the context stays suspended, leaving no worklet prepared", async () => {
+            const {capture, audioContext, preparedWorklets} =
+                await setup({state: "suspended", resumesTo: "suspended"})
+            await expect(capture.prepareRecording()).rejects.toBeDefined()
+            expect(audioContext.resumeCalls).toBe(1)
+            expect(preparedWorklets.length).toBe(0)
+        })
+
+        it("discards a worklet the previous prepare left behind", async () => {
+            const {capture, preparedWorklets, removedFromSampleManager, recordGainNode} = await setup()
+            await capture.prepareRecording()
+            const orphan = preparedWorklets[0]
+            const gainNode = recordGainNode()
+            await capture.prepareRecording()
+            expect(preparedWorklets.length).toBe(2)
+            expect(orphan.terminated).toBe(true)
+            expect(removedFromSampleManager).toEqual([orphan.uuid])
+            expect(gainNode.disconnected).toContain(orphan)
+            expect(preparedWorklets[1].terminated).toBe(false)
+        })
+    })
+
+    describe("starting a recording", () => {
+        it("discards the prepared worklet when the audio chain is gone", async () => {
+            const {capture, preparedWorklets, removedFromSampleManager} = await setup()
+            await capture.prepareRecording()
+            const worklet = preparedWorklets[0]
+            capture.armed.setValue(true)
+            capture.armed.setValue(false) // tears the audio chain down behind the prepared worklet
+            expect(capture.outputNode).toEqual(Option.None)
+            expect(capture.startRecording()).toBeDefined()
+            expect(worklet.terminated).toBe(true)
+            expect(removedFromSampleManager).toEqual([worklet.uuid])
+        })
+    })
+})

--- a/packages/studio/core/src/capture/CaptureAudio.ts
+++ b/packages/studio/core/src/capture/CaptureAudio.ts
@@ -6,11 +6,13 @@ import {
     Nullable,
     Option,
     RuntimeNotifier,
-    Terminable
+    Terminable,
+    tryCatch
 } from "@opendaw/lib-std"
 import {dbToGain} from "@opendaw/lib-dsp"
 import {Promises} from "@opendaw/lib-runtime"
 import {AudioUnitBox, CaptureAudioBox} from "@opendaw/studio-boxes"
+import {AudioContexts} from "../AudioContexts"
 import {Capture} from "./Capture"
 import {CaptureDevices} from "./CaptureDevices"
 import {InputLatency} from "./InputLatency"
@@ -176,6 +178,9 @@ export class CaptureAudio extends Capture<CaptureAudioBox> {
     async prepareRecording(): Promise<void> {
         const {project} = this.manager
         const {env: {audioContext, audioWorklets, sampleManager, sampleService}} = project
+        // A worklet still prepared here was never consumed by `startRecording`, so nothing will ever
+        // terminate it: it stays connected to the record gain and its reader keeps appending chunks.
+        this.#discardPreparedWorklet()
         if (isUndefined(audioContext.outputLatency)) {
             const approved = await RuntimeNotifier.approve({
                 headline: "Warning",
@@ -186,6 +191,13 @@ export class CaptureAudio extends Capture<CaptureAudioBox> {
             if (!approved) {
                 return Promise.reject("Recording cancelled")
             }
+        }
+        // The take is placed from reports the audio thread sends while rendering: a context that is
+        // not running sends none, and the transport would count in over a capture that records
+        // nothing. Rejecting here aborts the whole recording session before the transport starts.
+        await AudioContexts.resume(audioContext)
+        if (audioContext.state !== "running") {
+            return Promise.reject(`Cannot record while the audio context is '${audioContext.state}'.`)
         }
         await this.#streamGenerator()
         const audioChain = this.#audioChain
@@ -208,17 +220,26 @@ export class CaptureAudio extends Capture<CaptureAudioBox> {
         const recordingWorklet = this.#preparedWorklet
         if (!isDefined(audioChain) || !isDefined(recordingWorklet)) {
             console.warn("No audio chain or worklet available for recording.")
+            this.#discardPreparedWorklet()
             return Terminable.Empty
         }
         this.#preparedWorklet = null
         const {recordGainNode} = audioChain
         const track = this.#stream.unwrapOrNull()?.getAudioTracks().at(0)
         const trackSettings = track?.getSettings()
-        const outputLatency = audioContext.outputLatency ?? 0
-        const inputLatency = InputLatency.resolve(
-            this.captureBox.inputLatency.getValue(),
-            engine.preferences.settings.recording.inputLatency,
-            outputLatency)
+        // Both terms are read on demand: the input latency can be configured to equal the output
+        // latency, which is only known once output has started, so resolving it needs the same read.
+        const readLatency = (): RecordAudio.Latency => {
+            const outputLatency = audioContext.outputLatency ?? 0
+            return {
+                outputLatency,
+                inputLatency: InputLatency.resolve(
+                    this.captureBox.inputLatency.getValue(),
+                    engine.preferences.settings.recording.inputLatency,
+                    outputLatency)
+            }
+        }
+        const {inputLatency} = readLatency()
         console.debug("[CaptureAudio] latency report", {
             outputLatency: audioContext.outputLatency,
             baseLatency: audioContext.baseLatency,
@@ -233,8 +254,7 @@ export class CaptureAudio extends Capture<CaptureAudioBox> {
             sampleManager,
             project,
             capture: this,
-            outputLatency,
-            inputLatency
+            readLatency
         })
     }
 
@@ -299,6 +319,19 @@ export class CaptureAudio extends Capture<CaptureAudioBox> {
         sourceNode.connect(recordGainNode)
         this.#audioChain = {sourceNode, recordGainNode, channelCount}
         this.#connectMonitoring()
+    }
+
+    // The teardown `RecordAudio`'s terminator performs when it aborts a recording, for a worklet that
+    // never reached `RecordAudio` at all. Without it the node stays connected to the record gain and
+    // its ring reader appends every delivered chunk to an unbounded buffer for the life of the page.
+    #discardPreparedWorklet(): void {
+        const recordingWorklet = this.#preparedWorklet
+        if (!isDefined(recordingWorklet)) {return}
+        this.#preparedWorklet = null
+        // The chain may already be gone or rebuilt, in which case the node is no longer connected.
+        tryCatch(() => this.#audioChain?.recordGainNode.disconnect(recordingWorklet))
+        this.manager.project.env.sampleManager.remove(recordingWorklet.uuid)
+        recordingWorklet.terminate()
     }
 
     #destroyAudioChain(): void {

--- a/packages/studio/core/src/capture/RecordAudio.test.ts
+++ b/packages/studio/core/src/capture/RecordAudio.test.ts
@@ -4,6 +4,7 @@ import {ppqn, PPQN} from "@opendaw/lib-dsp"
 import {AudioRegionBoxAdapter, AudioUnitBoxAdapter, ProjectSkeleton} from "@opendaw/studio-adapters"
 import type {ProjectEnv} from "../project/ProjectEnv"
 import type {EngineWorklet} from "../EngineWorklet"
+import type {RecordingStart} from "../Engine"
 import type {RecordingWorklet} from "../RecordingWorklet"
 import {InputLatency} from "./InputLatency"
 import type {Capture} from "./Capture"
@@ -35,7 +36,7 @@ const createFakeWorklet = () => ({
     isCountingIn: new DefaultObservableValue(false),
     markerState: new DefaultObservableValue(null),
     cpuLoad: new DefaultObservableValue(0),
-    recordingStart: new MutableObservableOption<{contextTime: number, position: ppqn}>(),
+    recordingStart: new MutableObservableOption<RecordingStart>(),
     preferences: {update: () => {}, subscribeAll: () => Terminable.Empty}
 })
 

--- a/packages/studio/core/src/capture/RecordAudio.test.ts
+++ b/packages/studio/core/src/capture/RecordAudio.test.ts
@@ -1,0 +1,228 @@
+import {describe, expect, it} from "vitest"
+import {DefaultObservableValue, isDefined, MutableObservableOption, Option, Terminable, UUID} from "@opendaw/lib-std"
+import {ppqn, PPQN} from "@opendaw/lib-dsp"
+import {AudioRegionBoxAdapter, AudioUnitBoxAdapter, ProjectSkeleton} from "@opendaw/studio-adapters"
+import type {ProjectEnv} from "../project/ProjectEnv"
+import type {EngineWorklet} from "../EngineWorklet"
+import type {RecordingWorklet} from "../RecordingWorklet"
+import type {Capture} from "./Capture"
+
+// An audio take is placed from two audio-thread reports: the engine's `recordingStart` (context time and
+// playhead position at the end of the quantum recording began in) and the recording processor's
+// `firstQuantumTime` (context time of the buffer's first frame). The tests drive both by hand.
+
+if (!isDefined(Reflect.get(globalThis, "AudioWorkletNode"))) {
+    Reflect.set(globalThis, "AudioWorkletNode", class {})
+}
+
+const SAMPLE_RATE = 48_000
+
+const sampleManager = () => ({
+    getOrCreate: (uuid: UUID.Bytes) => ({
+        get data() {return Option.None}, get peaks() {return Option.None}, get uuid() {return uuid},
+        get state() {return {type: "idle"} as const}, invalidate() {}, subscribe: () => Terminable.Empty
+    }), record: () => {}, invalidate: () => {}, remove: () => {}, register: () => Terminable.Empty
+})
+
+const createFakeWorklet = () => ({
+    playbackTimestamp: new DefaultObservableValue(0),
+    countInBeatsRemaining: new DefaultObservableValue(0),
+    position: new DefaultObservableValue<ppqn>(0),
+    bpm: new DefaultObservableValue(120),
+    isPlaying: new DefaultObservableValue(false),
+    isRecording: new DefaultObservableValue(false),
+    isCountingIn: new DefaultObservableValue(false),
+    markerState: new DefaultObservableValue(null),
+    cpuLoad: new DefaultObservableValue(0),
+    recordingStart: new MutableObservableOption<{contextTime: number, position: ppqn}>(),
+    preferences: {update: () => {}, subscribeAll: () => Terminable.Empty}
+})
+
+const createFakeRecordingWorklet = () => ({
+    uuid: UUID.generate(),
+    firstQuantumTime: Option.None as Option<number>,
+    numberOfFrames: 0,
+    limits: new Array<number>(),
+    limit(count: number): void {this.limits.push(count)},
+    terminate(): void {},
+    setFillLength(): void {},
+    set onSaved(_: unknown) {},
+    get data() {return Option.None}
+})
+
+const setup = async () => {
+    const {Project} = await import("../project/Project")
+    const {RecordAudio} = await import("./RecordAudio")
+    const audioContext = {currentTime: 0, sampleRate: SAMPLE_RATE}
+    const env = {
+        audioContext, audioWorklets: undefined, sampleManager: sampleManager(),
+        soundfontManager: undefined, sampleService: undefined, soundfontService: undefined
+    } as unknown as ProjectEnv
+    const skeleton = ProjectSkeleton.empty({createDefaultUser: true, createOutputMaximizer: false})
+    const project = Project.fromSkeleton(env, skeleton)
+    const {primaryAudioUnitBox} = skeleton.mandatoryBoxes
+    const audioUnit = project.boxAdapters.adapterFor(primaryAudioUnitBox, AudioUnitBoxAdapter)
+    const worklet = createFakeWorklet()
+    project.engine.setWorklet(worklet as unknown as EngineWorklet)
+    project.editing.modify(() => project.timelineBox.loopArea.enabled.setValue(false))
+    const recordingWorklet = createFakeRecordingWorklet()
+    const capture = {
+        audioUnitBox: primaryAudioUnitBox,
+        addRecordedRegion: () => {}
+    } as unknown as Capture
+    const recorder = RecordAudio.start({
+        recordingWorklet: recordingWorklet as unknown as RecordingWorklet,
+        sourceNode: {disconnect: () => {}} as unknown as AudioNode,
+        sampleManager: project.env.sampleManager,
+        project,
+        capture,
+        outputLatency: 0.020,
+        inputLatency: 0.010
+    })
+    const regions = (): ReadonlyArray<AudioRegionBoxAdapter> => audioUnit.tracks.values()
+        .flatMap(track => track.regions.collection.asArray())
+        .filter(region => region.isAudioRegion())
+    const tick = (position: ppqn) => worklet.position.setValue(position)
+    const record = () => worklet.isRecording.setValue(true)
+    const startAt = (contextTime: number, position: ppqn) => worklet.recordingStart.wrap({contextTime, position})
+    const firstQuantumAt = (contextTime: number) => recordingWorklet.firstQuantumTime = Option.wrap(contextTime)
+    const deliver = (seconds: number) => recordingWorklet.numberOfFrames = Math.round(seconds * SAMPLE_RATE)
+    const stop = () => {
+        worklet.isRecording.setValue(false)
+        project.editing.modify(() => recorder.terminate(), false)
+    }
+    const loop = (from: ppqn, to: ppqn) => project.editing.modify(() => {
+        const {loopArea} = project.timelineBox
+        loopArea.from.setValue(from)
+        loopArea.to.setValue(to)
+        loopArea.enabled.setValue(true)
+    })
+    return {project, audioContext, recordingWorklet, regions, tick, record, startAt, firstQuantumAt, deliver, stop, loop}
+}
+
+describe("RecordAudio", () => {
+    describe("placing the first take", () => {
+        it("anchors the take on the engine's recording start and the buffer's first frame", async () => {
+            const {regions, tick, record, startAt, firstQuantumAt, deliver} = await setup()
+            firstQuantumAt(1.0)
+            startAt(1.5, PPQN.Bar)
+            deliver(0.6)
+            record()
+            tick(PPQN.Bar + 40) // the main thread observes the transport further along
+            expect(regions().length).toBe(1)
+            const region = regions()[0]
+            expect(region.position).toBe(PPQN.Bar)
+            // half a second of buffer precedes the start, plus outputLatency and inputLatency
+            expect(region.box.waveformOffset.getValue()).toBeCloseTo(0.5 + 0.020 + 0.010, 6)
+        })
+
+        it("moves a fractional start position into the offset", async () => {
+            const {regions, tick, record, startAt, firstQuantumAt, deliver} = await setup()
+            firstQuantumAt(1.0)
+            startAt(1.5, PPQN.Bar + 0.5)
+            deliver(0.6)
+            record()
+            tick(PPQN.Bar + 40)
+            const region = regions()[0]
+            expect(region.position).toBe(PPQN.Bar)
+            expect(region.box.waveformOffset.getValue())
+                .toBeCloseTo(0.530 - PPQN.pulsesToSeconds(0.5, 120), 6)
+        })
+
+        it("begins the take where the captured audio begins when the buffer's first frame postdates the start",
+            async () => {
+                const {regions, tick, record, startAt, firstQuantumAt, deliver} = await setup()
+                firstQuantumAt(2.03) // 0.5 s after the start, net of the two latency terms
+                startAt(1.5, PPQN.Bar)
+                deliver(0.1)
+                record()
+                tick(PPQN.Bar + 40)
+                const region = regions()[0]
+                expect(region.position).toBe(PPQN.Bar + PPQN.secondsToPulses(0.5, 120))
+                expect(region.box.waveformOffset.getValue()).toBeCloseTo(0.0, 6)
+            })
+
+        it("waits for both anchors before placing the take", async () => {
+            const {regions, tick, record, startAt, firstQuantumAt, deliver} = await setup()
+            firstQuantumAt(1.0)
+            deliver(0.6)
+            record()
+            tick(PPQN.Bar + 40)
+            expect(regions().length).toBe(0)
+            startAt(1.5, PPQN.Bar)
+            tick(PPQN.Bar + 80)
+            expect(regions().length).toBe(1)
+            expect(regions()[0].position).toBe(PPQN.Bar)
+        })
+
+        it("falls back to the main-thread observations once the wait for the anchors expires", async () => {
+            const {audioContext, regions, tick, record, deliver} = await setup()
+            audioContext.currentTime = 10.0
+            deliver(0.6)
+            record()
+            tick(PPQN.Bar + 40)
+            expect(regions().length).toBe(0)
+            audioContext.currentTime = 10.3
+            tick(PPQN.Bar + 80)
+            expect(regions().length).toBe(1)
+            const region = regions()[0]
+            expect(region.position).toBe(PPQN.Bar + 80)
+            expect(region.box.waveformOffset.getValue()).toBeCloseTo(0.6 + 0.020 + 0.010, 6)
+        })
+    })
+
+    describe("stopping", () => {
+        it("runs the take to the last frame the ring delivered and keeps every frame", async () => {
+            const {regions, recordingWorklet, tick, record, startAt, firstQuantumAt, deliver, stop} = await setup()
+            firstQuantumAt(1.0)
+            startAt(1.5, 0)
+            deliver(0.6)
+            record()
+            tick(40)
+            deliver(4.53) // the live duration becomes 4.53 - 0.53 = 4.0 s
+            tick(PPQN.Bar * 2)
+            deliver(4.56) // chunks keep arriving between the last position tick and the stop
+            stop()
+            expect(regions().length).toBe(1)
+            expect(regions()[0].box.duration.getValue()).toBeCloseTo(4.56 - 0.53, 5)
+            expect(recordingWorklet.limits).toEqual([Math.round(4.56 * SAMPLE_RATE)])
+        })
+
+        it("aborts a recording whose only take never grew past zero and removes its file box", async () => {
+            const {project, regions, recordingWorklet, tick, record, startAt, firstQuantumAt, deliver, stop} =
+                await setup()
+            firstQuantumAt(1.0)
+            startAt(1.5, 0)
+            deliver(0.3) // less than the 0.53 s the take's window begins at
+            record()
+            tick(40)
+            expect(regions().length).toBe(1)
+            expect(project.boxGraph.findBox(recordingWorklet.uuid).nonEmpty()).toBe(true)
+            stop()
+            expect(regions().length).toBe(0)
+            expect(recordingWorklet.limits).toEqual([])
+            expect(project.boxGraph.findBox(recordingWorklet.uuid).isEmpty()).toBe(true)
+        })
+
+        it("finalizes the earlier takes when the stop drops a take that never grew past zero", async () => {
+            const {regions, recordingWorklet, tick, record, startAt, firstQuantumAt, deliver, stop, loop} =
+                await setup()
+            loop(0, PPQN.Bar) // 2 s at 120 bpm
+            firstQuantumAt(1.0)
+            startAt(1.5, 0)
+            deliver(0.6)
+            record()
+            tick(40)
+            deliver(2.4)
+            tick(PPQN.Bar - 40)
+            // the wrap closes take 1 at the loop end and opens take 2, whose window starts 0.53 + 2 s
+            // into the buffer, ahead of what the ring has delivered so far
+            tick(20)
+            expect(regions().length).toBe(2)
+            expect(regions().map(region => region.box.duration.getValue() > 0)).toEqual([true, false])
+            stop()
+            expect(regions().length).toBe(1)
+            expect(recordingWorklet.limits).toEqual([recordingWorklet.numberOfFrames])
+        })
+    })
+})

--- a/packages/studio/core/src/capture/RecordAudio.test.ts
+++ b/packages/studio/core/src/capture/RecordAudio.test.ts
@@ -142,6 +142,22 @@ describe("RecordAudio", () => {
                 expect(region.box.waveformOffset.getValue()).toBeCloseTo(0.0, 6)
             })
 
+        it("rounds a covered start that falls between pulses up to the next one and keeps the rest in the offset",
+            async () => {
+                const {regions, tick, record, startAt, firstQuantumAt, deliver} = await setup()
+                // the first frame is 960.5 pulses late: the take cannot begin on the half pulse
+                firstQuantumAt(1.5 + 0.020 + 0.010 + PPQN.pulsesToSeconds(960.5, 120))
+                startAt(1.5, PPQN.Bar)
+                deliver(0.1)
+                record()
+                tick(PPQN.Bar + 1000)
+                const region = regions()[0]
+                expect(region.position).toBe(PPQN.Bar + 961)
+                // the audio covers the half pulse before the rounded position
+                expect(region.box.waveformOffset.getValue()).toBeCloseTo(PPQN.pulsesToSeconds(0.5, 120), 8)
+                expect(region.box.waveformOffset.getValue()).toBeGreaterThan(0)
+            })
+
         it("waits for both anchors before placing the take", async () => {
             const {regions, tick, record, startAt, firstQuantumAt, deliver} = await setup()
             firstQuantumAt(1.0)

--- a/packages/studio/core/src/capture/RecordAudio.test.ts
+++ b/packages/studio/core/src/capture/RecordAudio.test.ts
@@ -1,10 +1,11 @@
-import {describe, expect, it} from "vitest"
+import {describe, expect, it, vi} from "vitest"
 import {DefaultObservableValue, isDefined, MutableObservableOption, Option, Terminable, UUID} from "@opendaw/lib-std"
 import {ppqn, PPQN} from "@opendaw/lib-dsp"
 import {AudioRegionBoxAdapter, AudioUnitBoxAdapter, ProjectSkeleton} from "@opendaw/studio-adapters"
 import type {ProjectEnv} from "../project/ProjectEnv"
 import type {EngineWorklet} from "../EngineWorklet"
 import type {RecordingWorklet} from "../RecordingWorklet"
+import {InputLatency} from "./InputLatency"
 import type {Capture} from "./Capture"
 
 // An audio take is placed from two audio-thread reports: the engine's `recordingStart` (context time and
@@ -50,10 +51,18 @@ const createFakeRecordingWorklet = () => ({
     get data() {return Option.None}
 })
 
-const setup = async () => {
+// `inputLatency` is the engine preference, not the resolved term: the provider resolves it the way
+// CaptureAudio does, so `InputLatency.EqualsOutput` derives it from whichever output latency was read.
+const setup = async ({outputLatency = 0.020, inputLatency = 0.010}:
+                     {outputLatency?: number, inputLatency?: number} = {}) => {
     const {Project} = await import("../project/Project")
     const {RecordAudio} = await import("./RecordAudio")
     const audioContext = {currentTime: 0, sampleRate: SAMPLE_RATE}
+    let reportedOutputLatency = outputLatency
+    const readLatency = () => ({
+        outputLatency: reportedOutputLatency,
+        inputLatency: InputLatency.resolve(InputLatency.Inherit, inputLatency, reportedOutputLatency)
+    })
     const env = {
         audioContext, audioWorklets: undefined, sampleManager: sampleManager(),
         soundfontManager: undefined, sampleService: undefined, soundfontService: undefined
@@ -76,8 +85,7 @@ const setup = async () => {
         sampleManager: project.env.sampleManager,
         project,
         capture,
-        outputLatency: 0.020,
-        inputLatency: 0.010
+        readLatency
     })
     const regions = (): ReadonlyArray<AudioRegionBoxAdapter> => audioUnit.tracks.values()
         .flatMap(track => track.regions.collection.asArray())
@@ -97,7 +105,18 @@ const setup = async () => {
         loopArea.to.setValue(to)
         loopArea.enabled.setValue(true)
     })
-    return {project, audioContext, recordingWorklet, regions, tick, record, startAt, firstQuantumAt, deliver, stop, loop}
+    const reportOutputLatency = (seconds: number) => reportedOutputLatency = seconds
+    return {
+        project, audioContext, recordingWorklet, regions, tick, record, startAt, firstQuantumAt, deliver, stop, loop,
+        reportOutputLatency
+    }
+}
+
+const captureDebugLines = () => {
+    const lines = new Array<string>()
+    const spy = vi.spyOn(console, "debug")
+        .mockImplementation((...args: ReadonlyArray<unknown>) => {lines.push(args.map(String).join(" "))})
+    return {lines, restore: () => spy.mockRestore()}
 }
 
 describe("RecordAudio", () => {
@@ -171,6 +190,73 @@ describe("RecordAudio", () => {
             expect(regions()[0].position).toBe(PPQN.Bar)
         })
 
+        it("reads the output latency again when the take is placed", async () => {
+            const {lines, restore} = captureDebugLines()
+            try {
+                const {regions, tick, record, startAt, firstQuantumAt, deliver, reportOutputLatency} =
+                    await setup({outputLatency: 0}) // no output has been rendered yet when recording starts
+                reportOutputLatency(0.023)
+                firstQuantumAt(1.0)
+                startAt(1.5, PPQN.Bar)
+                deliver(0.6)
+                record()
+                tick(PPQN.Bar + 40)
+                expect(regions()[0].box.waveformOffset.getValue()).toBeCloseTo(0.5 + 0.023 + 0.010, 6)
+                expect(lines.filter(line => line.includes("outputLatency=")))
+                    .toEqual(["[RecordAudio] outputLatency=0.023 inputLatency=0.01 source=placement"])
+            } finally {
+                restore()
+            }
+        })
+
+        it("keeps the output latency read at start when the read at placement is still zero", async () => {
+            const {lines, restore} = captureDebugLines()
+            try {
+                const {regions, tick, record, startAt, firstQuantumAt, deliver} = await setup({outputLatency: 0})
+                firstQuantumAt(1.0)
+                startAt(1.5, PPQN.Bar)
+                deliver(0.6)
+                record()
+                tick(PPQN.Bar + 40)
+                expect(regions()[0].box.waveformOffset.getValue()).toBeCloseTo(0.5 + 0.010, 6)
+                expect(lines.filter(line => line.includes("outputLatency=")))
+                    .toEqual(["[RecordAudio] outputLatency=0 inputLatency=0.01 source=start"])
+            } finally {
+                restore()
+            }
+        })
+
+        it("resolves an input latency that equals the output latency from the read at placement", async () => {
+            const {regions, tick, record, startAt, firstQuantumAt, deliver, reportOutputLatency} =
+                await setup({outputLatency: 0, inputLatency: InputLatency.EqualsOutput})
+            reportOutputLatency(0.023)
+            firstQuantumAt(1.0)
+            startAt(1.5, PPQN.Bar)
+            deliver(0.6)
+            record()
+            tick(PPQN.Bar + 40)
+            // both terms follow the placement read, not the 0 the context reported while starting
+            expect(regions()[0].box.waveformOffset.getValue()).toBeCloseTo(0.5 + 0.023 + 0.023, 6)
+        })
+
+        it("carries the output latency read at placement into the takes a loop wrap opens", async () => {
+            const {regions, tick, record, startAt, firstQuantumAt, deliver, loop, reportOutputLatency} =
+                await setup({outputLatency: 0})
+            loop(0, PPQN.Bar) // 2 s at 120 bpm
+            reportOutputLatency(0.023)
+            firstQuantumAt(1.0)
+            startAt(1.5, 0)
+            deliver(0.6)
+            record()
+            tick(40)
+            deliver(2.4)
+            tick(PPQN.Bar - 40)
+            tick(20) // the wrap closes take 1 at the loop end and opens take 2
+            expect(regions().length).toBe(2)
+            expect(regions().map(region => region.box.waveformOffset.getValue()))
+                .toEqual([expect.closeTo(0.533, 6), expect.closeTo(2.533, 6)])
+        })
+
         it("falls back to the main-thread observations once the wait for the anchors expires", async () => {
             const {audioContext, regions, tick, record, deliver} = await setup()
             audioContext.currentTime = 10.0
@@ -184,6 +270,19 @@ describe("RecordAudio", () => {
             const region = regions()[0]
             expect(region.position).toBe(PPQN.Bar + 80)
             expect(region.box.waveformOffset.getValue()).toBeCloseTo(0.6 + 0.020 + 0.010, 6)
+        })
+
+        it("compensates the fallback take with the latency read at start", async () => {
+            const {audioContext, regions, tick, record, deliver, reportOutputLatency} = await setup()
+            audioContext.currentTime = 10.0
+            deliver(0.6)
+            record()
+            tick(PPQN.Bar + 40)
+            // a later read cannot reach a take the anchors never placed
+            reportOutputLatency(0.999)
+            audioContext.currentTime = 10.3
+            tick(PPQN.Bar + 80)
+            expect(regions()[0].box.waveformOffset.getValue()).toBeCloseTo(0.6 + 0.020 + 0.010, 6)
         })
     })
 

--- a/packages/studio/core/src/capture/RecordAudio.ts
+++ b/packages/studio/core/src/capture/RecordAudio.ts
@@ -33,6 +33,11 @@ export namespace RecordAudio {
         regionBox: AudioRegionBox
     }
 
+    // How long (context clock) to wait for the audio-thread anchors after the first recording callback
+    // before placing the take from main-thread observations instead. Both anchors are one-shot messages
+    // that normally arrive within a frame of that callback.
+    const ANCHOR_WAIT_SECONDS = 0.25
+
     export const start = (
         {recordingWorklet, sourceNode, sampleManager, project, capture, outputLatency, inputLatency}: RecordAudioContext)
         : Terminable => {
@@ -47,8 +52,10 @@ export namespace RecordAudio {
         let lastPosition: ppqn = 0
         let currentWaveformOffset: number = outputLatency + inputLatency
         let takeNumber: int = 0
+        let firstRecordingTick: Option<number> = Option.None
 
-        const {env: {audioContext: {sampleRate}}, engine: {preferences: {settings: {recording}}}} = project
+        const {env: {audioContext}, engine: {preferences: {settings: {recording}}}} = project
+        const {sampleRate} = audioContext
         const {loopArea} = timelineBox
 
         const createFileBox = () => {
@@ -175,32 +182,45 @@ export namespace RecordAudio {
         terminator.ownAll(
             Terminable.create(() => {
                 tryCatch(() => sourceNode.disconnect(recordingWorklet))
-                if (recordingWorklet.numberOfFrames === 0 || fileBox.isEmpty()) {
-                    console.debug("[RecordAudio] abort", {
-                        numberOfFrames: recordingWorklet.numberOfFrames,
-                        hasFile: fileBox.nonEmpty()
-                    })
+                // The source is disconnected: the ring delivers nothing beyond what it already holds, so
+                // the frames delivered so far are the whole recording. The current take runs to the last
+                // of them (the live update below only ran on position ticks, and chunks keep arriving
+                // between the last tick and the stop), and the file keeps them all.
+                const numberOfFrames = recordingWorklet.numberOfFrames
+                const totalSeconds = numberOfFrames / sampleRate
+                // fixes #840: short recordings (e.g. count-in) can leave zero-duration regions. A take
+                // that has not grown past zero yet (a stop right behind a loop wrap, for instance) is
+                // dropped the same way; the file still finalizes for the takes before it.
+                currentTake.ifSome(({regionBox}) => {
+                    if (!regionBox.isAttached()) {return}
+                    const takeSeconds = totalSeconds - currentWaveformOffset
+                    if (takeSeconds <= 0) {
+                        console.debug("[RecordAudio] stop: deleting zero-duration region", {takeNumber})
+                        editing.modify(() => regionBox.delete(), false)
+                        currentTake = Option.None
+                    } else {
+                        editing.modify(() => {
+                            regionBox.duration.setValue(takeSeconds)
+                            regionBox.loopDuration.setValue(takeSeconds)
+                        }, false)
+                    }
+                })
+                const hasTakes = fileBox.mapOr(box => box.isAttached() && !box.pointerHub.isEmpty(), false)
+                if (numberOfFrames === 0 || !hasTakes) {
+                    console.debug("[RecordAudio] abort", {numberOfFrames, hasTakes})
                     sampleManager.remove(originalUuid)
                     recordingWorklet.terminate()
-                } else {
-                    // fixes #840: short recordings (e.g. count-in) can leave zero-duration regions
-                    currentTake.ifSome(({regionBox}) => {
-                        const duration = regionBox.duration.getValue()
-                        if (duration <= 0) {
-                            console.debug("[RecordAudio] stop: deleting zero-duration region", {takeNumber})
-                            editing.modify(() => regionBox.delete(), false)
-                        } else {
-                            console.debug("[RecordAudio] stop", {
-                                takeNumber,
-                                duration,
-                                numberOfFrames: recordingWorklet.numberOfFrames
-                            })
-                            recordingWorklet.limit(Math.ceil((currentWaveformOffset + duration) * sampleRate))
-                        }
+                    fileBox.ifSome(box => {
+                        if (box.isAttached()) {editing.modify(() => box.delete(), false)}
                     })
+                } else {
+                    // Everything the ring delivered is kept; a limit above it would never be reached and
+                    // the recording would never finalize.
+                    console.debug("[RecordAudio] stop", {takeNumber, totalSeconds, numberOfFrames})
+                    recordingWorklet.limit(numberOfFrames)
                     fileBox.ifSome(box => {
                         if (box.isAttached()) {
-                            box.endInSeconds.setValue(recordingWorklet.numberOfFrames / sampleRate)
+                            box.endInSeconds.setValue(totalSeconds)
                         }
                     })
                 }
@@ -245,36 +265,67 @@ export namespace RecordAudio {
                 lastPosition = currentPosition
                 // Create fileBox and region together when recording starts.
                 if (fileBox.isEmpty()) {
-                    // Three terms make up the file_time of audio captured at engine timeline
-                    // = currentPosition (mic case):
-                    //   L                  — worklet head-start: wall-clock between the worklet
-                    //                        being connected (in prepareRecording) and the engine
-                    //                        actually beginning count-in. Cannot be derived from
-                    //                        BPM/signature alone.
-                    //   countInSeconds     — deterministic from bars × signature × bpm.
-                    //   outputLatency      — engine→speaker compensation.
-                    //   inputLatency       — manual mic→engine compensation (engine preferences,
-                    //                        optionally overridden per track in the CaptureAudioBox).
-                    // L is recovered once, here, by reading numberOfFrames at the moment we first
-                    // see isRecording=true and subtracting the BPM-derived countInSeconds. Earlier
-                    // attempts that omitted L put a systematic ~30 ms (one render dispatch) bias
-                    // on every take; earlier attempts that used numberOfFrames as the whole offset
-                    // were noisy by the same ~few ms but never wildly wrong.
-                    const countedIn = Recording.wasCountingIn()
-                    const barPPQN = PPQN.fromSignature(
-                        timelineBox.signature.nominator.getValue(),
-                        timelineBox.signature.denominator.getValue())
-                    const countInSeconds = countedIn
-                        ? PPQN.pulsesToSeconds(recording.countInBars * barPPQN, timelineBox.bpm.getValue())
-                        : 0
-                    const wallclockSinceWorklet = recordingWorklet.numberOfFrames / sampleRate
-                    const headStartSeconds = countedIn
-                        ? Math.max(0, wallclockSinceWorklet - countInSeconds)
-                        : wallclockSinceWorklet
-                    const waveformOffset = headStartSeconds + countInSeconds + outputLatency + inputLatency
+                    if (firstRecordingTick.isEmpty()) {firstRecordingTick = Option.wrap(audioContext.currentTime)}
+                    // Two one-shot audio-thread reports place the take: the engine's `recordingStart`
+                    // (context time and playhead position at the end of the quantum the transport began
+                    // recording in) and the processor's `firstQuantumTime` (context time of the buffer's
+                    // first frame). Each rides its own message channel and may trail the first recording
+                    // callback by a tick, so wait for both; fall back to the main-thread observations
+                    // only after a bounded wait (e.g. a processor bundle that never announces).
+                    const recordingStart = engine.recordingStart
+                    const firstQuantumTime = recordingWorklet.firstQuantumTime
+                    let takePosition: ppqn
+                    let waveformOffset: number
+                    if (recordingStart.nonEmpty() && firstQuantumTime.nonEmpty()) {
+                        const {contextTime, position} = recordingStart.unwrap()
+                        // Buffer time of the recording start, plus the two latency terms: the performer
+                        // plays to output that reaches them outputLatency late, and the input path
+                        // delivers their signal inputLatency later still.
+                        const startOffset = contextTime - firstQuantumTime.unwrap() + outputLatency + inputLatency
+                        // The region position is an integer field: floor it and move the remainder into
+                        // the offset, so the content does not shift by the fraction.
+                        takePosition = Math.floor(position)
+                        waveformOffset = startOffset - tempoMap.intervalToSeconds(takePosition, position)
+                        if (waveformOffset < 0) {
+                            // The buffer's first frame postdates the start: nothing covers the head, so
+                            // the take begins at the first integer position the captured audio covers.
+                            const startSeconds = tempoMap.ppqnToSeconds(takePosition)
+                            const coveredFrom = takePosition
+                                + tempoMap.intervalToPPQN(startSeconds, startSeconds - waveformOffset)
+                            takePosition = Math.ceil(coveredFrom)
+                            waveformOffset = tempoMap.intervalToSeconds(coveredFrom, takePosition)
+                        }
+                        console.debug(`[RecordAudio] anchored: contextTime=${contextTime} position=${position} `
+                            + `firstQuantumTime=${firstQuantumTime.unwrap()} takePosition=${takePosition} `
+                            + `waveformOffset=${waveformOffset}`)
+                    } else if (audioContext.currentTime - firstRecordingTick.unwrap() < ANCHOR_WAIT_SECONDS) {
+                        return
+                    } else {
+                        // Without the anchors, the ring reader's frame counter stands in for the elapsed
+                        // capture time and the observed position for the start. Both are main-thread
+                        // reads that trail the audio thread, so this places the take later on the
+                        // timeline than the audio it holds. Counting in: the count-in bars are part of
+                        // the elapsed capture but precede the start.
+                        const countedIn = Recording.wasCountingIn()
+                        const barPPQN = PPQN.fromSignature(
+                            timelineBox.signature.nominator.getValue(),
+                            timelineBox.signature.denominator.getValue())
+                        const countInSeconds = countedIn
+                            ? PPQN.pulsesToSeconds(recording.countInBars * barPPQN, timelineBox.bpm.getValue())
+                            : 0
+                        const wallclockSinceWorklet = recordingWorklet.numberOfFrames / sampleRate
+                        const headStartSeconds = countedIn
+                            ? Math.max(0, wallclockSinceWorklet - countInSeconds)
+                            : wallclockSinceWorklet
+                        takePosition = currentPosition
+                        waveformOffset = headStartSeconds + countInSeconds + outputLatency + inputLatency
+                        console.debug(`[RecordAudio] anchor fallback: recordingStart=${recordingStart.nonEmpty()} `
+                            + `firstQuantumTime=${firstQuantumTime.nonEmpty()} takePosition=${takePosition} `
+                            + `waveformOffset=${waveformOffset}`)
+                    }
                     editing.modify(() => {
                         fileBox = Option.wrap(createFileBox())
-                        currentTake = Option.wrap(createTakeRegion(currentPosition, waveformOffset, null))
+                        currentTake = Option.wrap(createTakeRegion(takePosition, waveformOffset, null))
                     }, false)
                     currentWaveformOffset = waveformOffset
                 }

--- a/packages/studio/core/src/capture/RecordAudio.ts
+++ b/packages/studio/core/src/capture/RecordAudio.ts
@@ -3,6 +3,7 @@ import {
     int,
     Nullable,
     Option,
+    Provider,
     Terminable,
     Terminator,
     tryCatch,
@@ -18,14 +19,22 @@ import {Recording} from "./Recording"
 import {RecordTrack} from "./RecordTrack"
 
 export namespace RecordAudio {
+    /** The two latency terms a take's waveform offset compensates, in seconds. */
+    export type Latency = {
+        outputLatency: number
+        inputLatency: number
+    }
+
     type RecordAudioContext = {
         recordingWorklet: RecordingWorklet
         sourceNode: AudioNode
         sampleManager: SampleLoaderManager
         project: Project
         capture: Capture
-        outputLatency: number
-        inputLatency: number
+        // Read on demand: `AudioContext.outputLatency` reads 0 in Chrome until output has actually been
+        // rendered to the device, which a recording started right after the context resumed precedes.
+        // The input term rides along because it can be configured to equal the output term.
+        readLatency: Provider<Latency>
     }
 
     type TakeData = {
@@ -39,9 +48,10 @@ export namespace RecordAudio {
     const ANCHOR_WAIT_SECONDS = 0.25
 
     export const start = (
-        {recordingWorklet, sourceNode, sampleManager, project, capture, outputLatency, inputLatency}: RecordAudioContext)
+        {recordingWorklet, sourceNode, sampleManager, project, capture, readLatency}: RecordAudioContext)
         : Terminable => {
-        console.debug("[RecordAudio] start", {outputLatency, inputLatency})
+        const startLatency = readLatency()
+        console.debug("[RecordAudio] start", startLatency)
         const terminator = new Terminator()
         const beats = PPQN.fromSignature(1, project.timelineBox.signature.denominator.getValue())
         const {editing, engine, boxGraph, timelineBox, tempoMap} = project
@@ -50,7 +60,10 @@ export namespace RecordAudio {
         let fileBox: Option<AudioFileBox> = Option.None
         let currentTake: Option<TakeData> = Option.None
         let lastPosition: ppqn = 0
-        let currentWaveformOffset: number = outputLatency + inputLatency
+        // Set from the take that is placed first, and read only through `currentTake`, which stays
+        // empty until that placement — so the takes a loop wrap opens inherit the latency the take
+        // was placed with, never the one read at `start`.
+        let currentWaveformOffset: number = 0
         let takeNumber: int = 0
         let firstRecordingTick: Option<number> = Option.None
 
@@ -278,6 +291,16 @@ export namespace RecordAudio {
                     let waveformOffset: number
                     if (recordingStart.nonEmpty() && firstQuantumTime.nonEmpty()) {
                         const {contextTime, position} = recordingStart.unwrap()
+                        // The engine has reported its recording start, so at least one quantum has reached
+                        // the device and the context can report an output latency it did not have while
+                        // starting. Read both terms again here (the input term can be derived from the
+                        // output one) and keep the pair from `start` when the output term stays unset.
+                        const placedLatency = readLatency()
+                        const placed = Number.isFinite(placedLatency.outputLatency)
+                            && placedLatency.outputLatency > 0
+                        const {outputLatency, inputLatency} = placed ? placedLatency : startLatency
+                        console.debug(`[RecordAudio] outputLatency=${outputLatency} inputLatency=${inputLatency} `
+                            + `source=${placed ? "placement" : "start"}`)
                         // Buffer time of the recording start, plus the two latency terms: the performer
                         // plays to output that reaches them outputLatency late, and the input path
                         // delivers their signal inputLatency later still.
@@ -318,7 +341,8 @@ export namespace RecordAudio {
                             ? Math.max(0, wallclockSinceWorklet - countInSeconds)
                             : wallclockSinceWorklet
                         takePosition = currentPosition
-                        waveformOffset = headStartSeconds + countInSeconds + outputLatency + inputLatency
+                        waveformOffset = headStartSeconds + countInSeconds
+                            + startLatency.outputLatency + startLatency.inputLatency
                         console.debug(`[RecordAudio] anchor fallback: recordingStart=${recordingStart.nonEmpty()} `
                             + `firstQuantumTime=${firstQuantumTime.nonEmpty()} takePosition=${takePosition} `
                             + `waveformOffset=${waveformOffset}`)

--- a/packages/studio/core/src/capture/RecordAutomation.test.ts
+++ b/packages/studio/core/src/capture/RecordAutomation.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it, vi} from "vitest"
-import {DefaultObservableValue, isDefined, Option, Terminable, unitValue, UUID} from "@opendaw/lib-std"
+import {DefaultObservableValue, isDefined, MutableObservableOption, Option, Terminable, unitValue, UUID} from "@opendaw/lib-std"
 import {ppqn, PPQN} from "@opendaw/lib-dsp"
 import {
     AudioUnitBoxAdapter,
@@ -50,6 +50,7 @@ const createFakeWorklet = () => ({
     isCountingIn: new DefaultObservableValue(false),
     markerState: new DefaultObservableValue(null),
     cpuLoad: new DefaultObservableValue(0),
+    recordingStart: new MutableObservableOption(),
     preferences: {update: () => {}, subscribeAll: () => Terminable.Empty}
 })
 

--- a/packages/studio/core/src/project/RestartChainTerminated.test.ts
+++ b/packages/studio/core/src/project/RestartChainTerminated.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "vitest"
-import {DefaultObservableValue, isDefined, Option, Terminable, UUID} from "@opendaw/lib-std"
+import {DefaultObservableValue, isDefined, MutableObservableOption, Option, Terminable, UUID} from "@opendaw/lib-std"
 import {ProjectSkeleton} from "@opendaw/studio-adapters"
 import type {ProjectEnv} from "./ProjectEnv"
 import type {RestartWorklet} from "./Project"
@@ -39,6 +39,7 @@ const createFakeWorklet = () => {
         isCountingIn: new DefaultObservableValue(false),
         markerState: new DefaultObservableValue(null),
         cpuLoad: new DefaultObservableValue(0),
+        recordingStart: new MutableObservableOption(),
         preferences: {update: () => {}, subscribeAll: () => Terminable.Empty},
         context: {destination: {}},
         addEventListener: (type: string, listener: (event: unknown) => void) => {


### PR DESCRIPTION
### The problem

Audio takes are placed early on the timeline. Measured against the project's
absolute beat grid, the placement bias runs **−34.97 to −52.51 ms** as a per-cell
mean across 18 of the 20 cells of a live matrix on `@opendaw/studio-sdk@0.0.170`
(`recaudit-summary-1788310164556.json` at 48000 Hz, `…1788310817094.json` at
44100 Hz), and no individual take exceeds **−59.33 ms**. It appears on **every**
scenario measured — starting from bar 1 both with and without a count-in, on an
idle and on a blocked main thread, on a mid-timeline punch-in, and on each take of
a loop-wrap sequence — at both sample rates tested (44100, 48000) and both tempi
(120, 97.3 bpm). The two cells without a figure are `loop-wrap` cells where every
repeat failed to finalize (the third defect below).

Content lands early, so the head of a performance sits ahead of the downbeat the
musician played to.

### Where the error comes from

Three things in the recording path produce it, two of them found only by
instrumenting the installed build.

**1. Main-thread anchors.** `RecordAudio.ts` derives the take's `waveformOffset`
from two quantities read on the main thread:

```ts
const wallclockSinceWorklet = recordingWorklet.numberOfFrames / sampleRate
const headStartSeconds = countedIn
    ? Math.max(0, wallclockSinceWorklet - countInSeconds)
    : wallclockSinceWorklet
const waveformOffset = headStartSeconds + countInSeconds + outputLatency + inputLatency
```

`numberOfFrames` counts chunks as the ring reader delivers them and starts at
`prepareRecording()`'s `recordGainNode.connect(recordingWorklet)`, before the
transport leaves its start position; `currentPosition` is the position observed on
the first `isRecording=true` callback, by which time the transport has already
advanced. Both trail the audio thread by the main thread's scheduling lag, and
nothing pairs them to one instant. Worked example, from
`recaudit-summary-1788310164556.json` (`nominal-start`/120 bpm, repeat 3):
`regionPositionPpqn = 5`, so `regionStartSec = 0.0026042`, while
`waveformOffsetSec = 0.057667` — the frame-count clock and the PPQN clock, read at
the same tick, disagree by roughly 13× once the 23 ms `outputLatency` term is netted
out.

**2. `RecordingWorklet.#finalize` kept the wrong end of the buffer.** The ring
delivers whole chunks and runs past the `limit` at stop — on six of six single-take
repeats instrumented on 0.0.170 (`recaudit-summary-1788328085978.json`, per-row
`finalizeOvershootFrames`) the ring held 1535–2431 frames (32.0–50.6 ms) more than
the limit when `limit()` was called — and
`#finalize` did `frame.slice(-totalSamples)`, the LAST `limit` frames. The imported
file therefore began that many frames into the capture, while the regions still
addressed it from frame 0 through `waveformOffset`: every take shifted early by the
overshoot, a per-recording random amount that no anchor arithmetic can see. (The
`onSaved` comment in `RecordAudio.ts` already assumed the truncation happens at the
tail.)

**3. A stop right behind a loop wrap never finalized.** When the current take's
live duration is still `<= 0` at stop — the case immediately after a wrap, while the
ring has not yet delivered past the chained offset — the stop path deleted the
region under the #840 zero-duration rule and never called `limit()`, so `#finalize`
never ran and the loader stayed in `{type: "record"}` indefinitely. Instrumented on
0.0.170 (`recaudit-summary-1788327757434.json`, 6 loop-wrap repeats, per-row
`finalizeLimitCalls` / `finalizeLoaderState`): 4 of 6 never finalized, all four with
no `limit()` call and the loader still in `record` after the wait, while the ring had
kept delivering; both finalized repeats had exactly one call. The placement bias
widens that window, since it inflates every chained waveform offset.

**4. `outputLatency` read before output has started.** `CaptureAudio.startRecording()`
read `audioContext.outputLatency` once, at the start, and Chrome reports it as 0 until
audio has actually been rendered to the device. On a session's first recording the
snapshot was taken while it was still 0, so that take — and, through
`InputLatency.EqualsOutput`, its input term — got no output compensation, while later
takes in the same session did.

### What the branch changes

- **`EngineToClient.recordingStarted(contextTime, position)`.** The wasm processor
  reports, once per recording and straight from the engine state after `render()`,
  the context time at the END of the quantum in which the transport began recording,
  paired with the playhead position after that quantum — one instant, one message,
  on the channel `switchMarkerState` already uses. `EngineWorklet` keeps it as
  `recordingStart` (an `ObservableOption`, cleared when a recording is prepared),
  `EngineFacade` mirrors it, the `Engine` interface declares it. The sync packet is
  untouched. Both messages carry a recording generation: `prepareRecordingState`
  sends one the worklet increments per call, the processor echoes it in
  `recordingStarted`, and the worklet drops a report whose generation is not the
  current one — a report posted for the previous recording and delivered after the
  next one was prepared can no longer repopulate the cleared anchor and be paired
  with the new recording's `firstQuantumTime`.
- **`RecordingProcessor`** posts the context time of the buffer's first captured
  frame, gated like the ring writer so setup-phase quanta are skipped;
  `RecordingWorklet` exposes it as `firstQuantumTime`.
- **`RecordAudio`** places the first take on the first `isRecording` tick with both
  reports present: `waveformOffset = (start.contextTime − firstQuantumTime) +
  outputLatency + inputLatency`, positioned at `start.position` (floored to the
  integer field with the fraction moved into the offset; a first frame that
  postdates the start moves the take to the first position the audio covers). Only
  after a 0.25 s wait on the context clock does it fall back to the previous
  main-thread arithmetic, with a debug line naming the missing report. Loop-wrap
  takes keep the existing chained offset.
- **The stop path keeps every frame the ring delivered before the source was
  disconnected.** The current take's duration is set to the delivered length (the
  live update only ran on position ticks, and chunks keep arriving between the last
  tick and the stop), `#finalize` keeps the FIRST `limit` frames (`recordedFrames`)
  and the file is limited to exactly the delivered frame count, so the worklet
  finalizes immediately and nothing is dropped at either end — on the branch the
  file ends 24–78 ms after the stop request and the take extends to it. A take whose
  delivered length is still ≤ 0 is dropped and the file still finalizes for the takes
  before it; a recording that leaves no take at all is aborted and its file box
  deleted instead of leaking a loader in the recording state.
- **A recording restart handled between two renders is announced.** `write_engine_state`
  only runs inside `render`, so a `stopRecording`/`stop` followed by a
  `prepareRecordingState` between two quanta left the rendered `isRecording` flag at 1 on
  both reads and the restart's `recordingStarted` was dropped. The edge detection lives
  in `RecordingStartEdge` and both stop command handlers reset it; `prepareRecordingState`
  is deliberately not a reset site, since the engine ignores it while a recording runs and
  a reset there would re-announce a running recording.
- **The recording latency is read again at the moment the first take is placed.**
  `RecordAudio` takes a provider of both latency terms and calls it a second time on the
  placement path, which runs off the engine's `recordingStart` report and is therefore
  always at least one rendered quantum in. The pair read at placement wins when its output
  term is finite and positive; otherwise the pair read at start stands, and a debug line
  names which was used. The accepted pair also sets the offset chain the loop-wrap takes
  inherit.
- **`prepareRecording` resumes the context and rejects if it is still not running.** Both
  anchors are reported from rendered quanta, so a context that never renders places no
  take and the transport would count in over a capture that records nothing. Rejecting in
  `prepareRecording` aborts the whole session before the transport starts —
  `Recording.start` already turns a rejected prepare into a warning and clears its
  recording flag — which refusing in `startRecording` could not do, since its return value
  is not inspected. A worklet prepared for a recording that then refuses to start is
  disposed rather than left connected with its ring reader appending chunks for the life
  of the page.
- **Tests:** `packages/studio/core/src/capture/RecordAudio.test.ts` (14) — anchored
  placement, fractional position, a first frame after the start, waiting for both
  reports, the fallback after the wait, the stop extending the take to the delivered
  frames, the stop behind a wrap, the abort, the second latency read, the fallback to the
  start pair, the `EqualsOutput` input term and the wrap-chain propagation;
  `CaptureAudio.test.ts` (5) — the resume, the rejection, and the worklet disposal on both
  refusal paths; `RecordingWorklet.test.ts` (3) — `recordedFrames` on ramp chunks,
  asserting frame values; `core-wasm/test/recording-state.test.ts` — a stop and an
  immediate restart handled between renders, announced only when the edge was reset (a
  control edge left alone misses it), with the sync channels closed on every exit;
  `core-wasm/test/recording-start-edge.test.ts` (3) — the edge itself.

### Measured effect

Live matrix: 5 scenarios × 2 bpms (120, 97.3) × 2 rates (44100, 48000) × 3 repeats
(12 wrap takes per loop-wrap cell), recorded through a synthetic in-context digital
loopback so that the measurement carries no real device latency. Take placement is
judged against the project's **absolute** beat grid, and a harness-path
`outputLatency` term of 23 ms is netted out of the classification math on both sides
equally.

| | per-cell mean placement error | cells |
|---|---|---|
| `@opendaw/studio-sdk@0.0.170` | **−34.97 … −52.51 ms** | 18 (2 lost to the finalization hang) |
| this branch | **+9.33 … +23.77 ms** | 20 |

The magnitude falls on **all 18 comparable cells**, to 18–61 % of the 0.0.170 value,
and the sign flips to late; the per-scenario ranges overlap completely (nominal
9.33–22.36, blocked main thread 15.00–23.77, punch-in 17.00–21.56, count-in
15.44–21.40, loop-wrap 10.78–21.28 ms). Within every loop-wrap repeat, takes 1–4 agree
to ≤ 0.14 ms and take 0 sits within 0.08 ms of their mean. Head and tail integrity:
the harness's head and tail deficits are 0 on all 120 branch rows (0.0.170: head
deficit > 2 ms on 5 of 60 rows, tail 0). The harness's own classifier reads
`investigate` on 12 of the 20 branch cells — its "no band matched" verdict for a late
mean of 15–24 ms — and a known-signature band on the other 8 by coincidence of
magnitude; none of the 20 verdicts is produced by a head or tail deficit.

**What the remainder is.** The branch's `RecordingWorklet.firstQuantumTime` gives
the SDK's own context time of the buffer's first frame; the harness independently
estimates the same instant from reference clicks it schedules on the context and
recovers from the capture. Their difference is the loopback path's own input delay
(`MediaStreamAudioDestinationNode → getUserMedia → MediaStreamAudioSourceNode`):
**9.62–22.92 ms, different per stream instance**, over all 60 take-0 rows. Netting
it out of the adjusted median leaves **+1.13 … +1.19 ms on 59 of 60 rows** (the 60th
is a harness-artifact row, below), a rate-independent constant inside the harness's
2 ms tolerance and consistent with onset-detector latency. The SDK's first captured
frame follows the record request by 0–3 render quanta on every row. On a real input
that delay is what the `inputLatency` preference exists for; this change does not
set it.

Loop-wrap finalization: **0 of 12** repeats on this branch fail against **10 of 12**
on 0.0.170 (both finalize in 72–100 ms when they do). The per-repeat probe on 0.0.170
(`recaudit-summary-1788327757434.json`) shows every hung repeat with no `limit()`
call and the loader still recording; on the branch every repeat has exactly one call
with zero overshoot.

Artifacts: 0.0.170 baseline `recaudit-summary-1788310164556.json` (48000 Hz) and
`…1788310817094.json` (44100 Hz); this branch `…1788328219906.json` (48000 Hz) and
`…1788328656062.json` (44100 Hz), 60 rows each, no error rows. One row per branch
run (`nominal-start`/120/repeat 1, the first cell of each session) was measured with
the harness's `outputLatency` term read as 0 — a harness artifact (Chrome reports 0
until output has started), re-adjusted in the register; the ranges above use the
persisted values. An earlier build of this branch, whose stop path limited the file
to the last position tick's duration, truncated up to 5.8 ms of audio before the
stop request and failed the harness's tail-integrity gate on 94 of 120 rows; that is
the reason the stop path now keeps every delivered frame, and those runs are kept in
the register as history.

### What this does not fix

Each of the following is reported as its own issue (#374, #375), so none of them depends on this
change being taken.

- **#374 — The input path's own delay is not compensated automatically.** After this
  change the takes on the harness sit late by exactly the loopback's input delay
  (10–23 ms here). On a real device that is the `inputLatency` preference's job; the
  issue records the 0.0.170 signature and what remains afterwards.
- **#375 — A content-address collision on simultaneous identical takes**, which panics
  `BoxGraph.stageBox` and hangs the affected capture's finalization — unchanged: 6 of
  12 simultaneous-capture repeats on the two 0.0.170 runs
  (`recaudit-mt-summary-1788302627819.json`, `…1788302870379.json`) and 9 of 18 on the
  three runs on this branch (`…1788325292003.json`, `…1788325557229.json`,
  `…1788329084394.json`).

Inter-track skew between simultaneously armed captures, measured at ±1 render quantum
on 0.0.170, is not listed: on this branch each tape's residual after netting its own
input delay is identical (+1.15 ms on both tapes of every successful repeat) and the
measured skew equals the difference of the two loopback streams' delays exactly, so
with both captures anchored on the same `recordingStarted` instant there is no SDK-side
skew left to report.

### Reproducing the measurement

The harness is an unlisted debug demo in a separate repository and runs only on a
local HTTPS dev server — **there is no public URL for it.**

```
recording-alignment-audit-debug-demo.html?scenario=<name|all>&bpm=<n|all>&rate=<44100|48000>
```

Scenarios: `nominal-start`, `janked-start`, `midtimeline-start`, `countin-start`,
`loop-wrap`, plus `multitrack-start` / `multitrack-janked` for the simultaneous-capture
cells. Each run writes a summary JSON and one WAV per repeat; the offline
recomputation of every figure above is
`scripts/audit/recording-alignment/task9-branch-verification.ts`.

Full campaign register, including every prediction that was refuted or withdrawn and
the harness measurement defects that were found and fixed mid-campaign:
https://github.com/naomiaro/opendaw-test/blob/main/debug/recording-start-alignment-audit.md (merged as naomiaro/opendaw-test#123)

### Verification

- `npx turbo run build --filter=@opendaw/studio-core --filter=@opendaw/studio-core-processors --filter=@opendaw/studio-core-workers` — 16 tasks successful, no TypeScript errors.
- `npm run build:bundles` in `packages/studio/core-wasm` — both bundles emitted.
- `npm run typecheck` in `packages/studio/core-wasm` — zero errors in `src/`; the
  pre-existing set under `test/` is identical before and after the change.
- `npm test` in `packages/studio/core` — 46 files, 422 tests passing (400 before this
  branch plus the 22 new ones); unchanged by the generation commit, which alters no
  tested path's behaviour and whose fixture now uses the `RecordingStart` type.
- core-wasm targeted vitest (`recording-state`, `recording-start-edge`) — 8 passing; the
  engine-level cases need `dist/wasm` built first, as the existing `recording-state` tests
  already do.
- The live matrix above, on this branch built from `main`.

A Rust rebuild is not required: the change is entirely JS/TS. `write_engine_state` and
its byte-offset constants are untouched; the processor reads the recording flag and
position from the same state buffer it already decodes for the sync packet.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved recording synchronization using precise audio-clock and timeline positions.
  - Improved latency handling for fractional offsets, delayed starts, and looped recording.
  - Recording finalization now preserves the correct audio length and leading frames.
  - Recording restarts are detected reliably for accurate timing on new takes.
  - Improved recording preparation by resuming audio contexts and cleaning up unused recording resources.
  - Recording timing information is now exposed consistently for more accurate capture placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



