### PR TITLE
feat(capture): resolve input latency from the reported stream latency

### DIFF
--- a/packages/app/studio/src/ui/PreferencePanel.tsx
+++ b/packages/app/studio/src/ui/PreferencePanel.tsx
@@ -1,6 +1,6 @@
 import css from "./PreferencePanel.sass?inline"
 import {Html} from "@opendaw/lib-dom"
-import {Lifecycle, Optional} from "@opendaw/lib-std"
+import {Lifecycle, Optional, ValueGuard} from "@opendaw/lib-std"
 import {createElement, Frag} from "@opendaw/lib-jsx"
 import {Colors, IconSymbol} from "@opendaw/studio-enums"
 import {Checkbox} from "@/ui/components/Checkbox"
@@ -30,16 +30,28 @@ export type SelectOptions<T> = {
             : never
 }
 
+// Numeric fields are edited as free text, so a setting whose schema constrains its range needs a guard
+// here as well. Without one an out-of-range value is stored and fails the schema on the next load,
+// which costs the user that whole settings section.
+export type ValueGuards<T> = {
+    [K in keyof T]?: T[K] extends Primitive
+        ? T[K] extends number ? ValueGuard<number> : never
+        : T[K] extends object
+            ? ValueGuards<T[K]>
+            : never
+}
+
 type Construct<ROOT_SETTINGS, SETTINGS = ROOT_SETTINGS> = {
     lifecycle: Lifecycle
     preferences: Preferences<ROOT_SETTINGS>
     pathPrefix?: ReadonlyArray<string>
     labels: NestedLabels<SETTINGS>
     options?: SelectOptions<SETTINGS>
+    guards?: ValueGuards<SETTINGS>
 }
 
 export const PreferencePanel = <ROOT_SETTINGS, SETTINGS = ROOT_SETTINGS>(
-    {lifecycle, preferences, pathPrefix = [], labels, options}: Construct<ROOT_SETTINGS, SETTINGS>
+    {lifecycle, preferences, pathPrefix = [], labels, options, guards}: Construct<ROOT_SETTINGS, SETTINGS>
 ) => {
     const settings = pathPrefix.reduce(
         (obj, key) => (obj as Record<string, unknown>)[key],
@@ -57,6 +69,7 @@ export const PreferencePanel = <ROOT_SETTINGS, SETTINGS = ROOT_SETTINGS>(
                 if (typeof setting === "object" && setting !== null && typeof label === "object" && "fields" in label) {
                     const nestedLabels = label as { label: string; fields: NestedLabels<typeof setting> }
                     const nestedOptions = options?.[pKey] as Optional<SelectOptions<typeof setting>>
+                    const nestedGuards = guards?.[pKey] as Optional<ValueGuards<typeof setting>>
                     return (
                         <details className="accordion" open>
                             <summary>{nestedLabels.label}</summary>
@@ -65,7 +78,8 @@ export const PreferencePanel = <ROOT_SETTINGS, SETTINGS = ROOT_SETTINGS>(
                                 preferences={preferences}
                                 pathPrefix={currentPath}
                                 labels={nestedLabels.fields}
-                                options={nestedOptions}/>
+                                options={nestedOptions}
+                                guards={nestedGuards}/>
                         </details>
                     )
                 }
@@ -113,11 +127,16 @@ export const PreferencePanel = <ROOT_SETTINGS, SETTINGS = ROOT_SETTINGS>(
                                 </div>
                             )
                         }
+                        const fieldGuard = guards?.[pKey] as Optional<ValueGuard<number>>
                         return (
                             <div className="number-field">
                                 <span style={{color: Colors.shadow.toString()}}>{label}</span>
                                 <hr/>
-                                <NumberInput lifecycle={lifecycle} model={createModel()} maxChars={4} className="big"/>
+                                <NumberInput lifecycle={lifecycle}
+                                             model={createModel()}
+                                             guard={fieldGuard}
+                                             maxChars={4}
+                                             className="big"/>
                             </div>
                         )
                     }

--- a/packages/app/studio/src/ui/pages/PreferencesPage.tsx
+++ b/packages/app/studio/src/ui/pages/PreferencesPage.tsx
@@ -46,7 +46,8 @@ export const PreferencesPage: PageFactory<StudioService> = ({lifecycle, service}
                     <PreferencePanel lifecycle={lifecycle}
                                      preferences={service.engine.preferences}
                                      labels={PreferencesPageLabels.EngineSettingsLabels}
-                                     options={PreferencesPageLabels.EngineSettingsOptions}/>
+                                     options={PreferencesPageLabels.EngineSettingsOptions}
+                                     guards={PreferencesPageLabels.EngineSettingsGuards}/>
                 </section>
                 <section>
                     <div className="shortcuts">

--- a/packages/app/studio/src/ui/pages/PreferencesPageLabels.ts
+++ b/packages/app/studio/src/ui/pages/PreferencesPageLabels.ts
@@ -1,4 +1,4 @@
-import {NestedLabels} from "@/ui/PreferencePanel"
+import {NestedLabels, ValueGuards} from "@/ui/PreferencePanel"
 import {FpsOptions, OverlappingRegionsBehaviourOptions, StudioSettings} from "@opendaw/studio-core"
 import {EngineSettings} from "@opendaw/studio-adapters"
 
@@ -116,7 +116,7 @@ export namespace PreferencesPageLabels {
                 automationEnabled: "Record automation",
                 olderTakeAction: "Older take action",
                 olderTakeScope: "Older take scope",
-                inputLatency: "Input latency"
+                inputLatency: "Input latency (seconds, -1 = output latency, -3 = reported)"
             }
         }
     }
@@ -135,6 +135,15 @@ export namespace PreferencesPageLabels {
                 value,
                 label: value === "all" ? "All takes" : value === "previous-only" ? "Previous only" : "None"
             }))
+        }
+    }
+
+    export const EngineSettingsGuards: ValueGuards<EngineSettings> = {
+        metronome: {
+            gain: {guard: value => Math.min(EngineSettings.MetronomeGainMaximum, value)}
+        },
+        recording: {
+            inputLatency: {guard: value => Math.max(EngineSettings.InputLatencyMinimum, value)}
         }
     }
 }

--- a/packages/studio/adapters/src/engine/EnginePreferencesSchema.ts
+++ b/packages/studio/adapters/src/engine/EnginePreferencesSchema.ts
@@ -4,12 +4,20 @@ const _BeatSubDivisionOptions = [1, 2, 4, 8] as const
 const _RecordingCountInBars = [1, 2, 3, 4, 5, 6, 7, 8] as const
 const _OlderTakeActionOptions = ["disable-track", "mute-region"] as const
 const _OlderTakeScopeOptions = ["none", "all", "previous-only"] as const
+// Bounds of the two free numeric settings. Editors have to clamp to them, since a value outside the
+// bound fails the schema and costs the user that whole settings section on the next load.
+// Input latency is a number of seconds, or one of the InputLatency sentinels: -1 equals the output
+// latency, -3 takes whatever latency the capture's own MediaStreamTrack reports. The most negative
+// sentinel is the field's lower bound.
+const _InputLatencyMinimum = -3
+// Metronome gain is attenuation only, in decibel.
+const _MetronomeGainMaximum = 0
 
 export const EngineSettingsSchema = z.object({
     metronome: z.object({
         enabled: z.boolean(),
         beatSubDivision: z.union(_BeatSubDivisionOptions.map(value => z.literal(value))),
-        gain: z.number().min(Number.NEGATIVE_INFINITY).max(0),
+        gain: z.number().min(Number.NEGATIVE_INFINITY).max(_MetronomeGainMaximum),
         monophonic: z.boolean()
     }).default({
         enabled: false,
@@ -37,20 +45,22 @@ export const EngineSettingsSchema = z.object({
         automationEnabled: z.boolean(),
         olderTakeAction: z.union(_OlderTakeActionOptions.map(value => z.literal(value))),
         olderTakeScope: z.union(_OlderTakeScopeOptions.map(value => z.literal(value))),
-        inputLatency: z.number().min(-1)
+        inputLatency: z.number().min(_InputLatencyMinimum)
     }).default({
         countInBars: 1,
         allowTakes: true,
         automationEnabled: true,
         olderTakeAction: "mute-region",
         olderTakeScope: "previous-only",
-        inputLatency: 0
+        inputLatency: _InputLatencyMinimum // the Reported sentinel
     })
 })
 
 export type EngineSettings = z.infer<typeof EngineSettingsSchema>
 
 export namespace EngineSettings {
+    export const InputLatencyMinimum = _InputLatencyMinimum
+    export const MetronomeGainMaximum = _MetronomeGainMaximum
     export const BeatSubDivisionOptions = _BeatSubDivisionOptions
     export const RecordingCountInBars = _RecordingCountInBars
     export const OlderTakeActionOptions = _OlderTakeActionOptions

--- a/packages/studio/core/src/capture/CaptureAudio.ts
+++ b/packages/studio/core/src/capture/CaptureAudio.ts
@@ -215,15 +215,17 @@ export class CaptureAudio extends Capture<CaptureAudioBox> {
         const track = this.#stream.unwrapOrNull()?.getAudioTracks().at(0)
         const trackSettings = track?.getSettings()
         const outputLatency = audioContext.outputLatency ?? 0
-        const inputLatency = InputLatency.resolve(
+        const {seconds: inputLatency, source: inputLatencySource} = InputLatency.resolveWithSource(
             this.captureBox.inputLatency.getValue(),
             engine.preferences.settings.recording.inputLatency,
-            outputLatency)
+            outputLatency,
+            trackSettings?.latency)
         console.debug("[CaptureAudio] latency report", {
             outputLatency: audioContext.outputLatency,
             baseLatency: audioContext.baseLatency,
             inputLatencyReported: trackSettings?.latency,
             inputLatencyApplied: inputLatency,
+            inputLatencySource,
             deviceId: trackSettings?.deviceId,
             deviceLabel: track?.label
         })

--- a/packages/studio/core/src/capture/InputLatency.test.ts
+++ b/packages/studio/core/src/capture/InputLatency.test.ts
@@ -1,0 +1,135 @@
+import {describe, expect, it} from "vitest"
+import {EngineSettings} from "@opendaw/studio-adapters"
+import {InputLatency} from "./InputLatency"
+
+// The resolution order is: per-capture override (unless it is exactly Inherit), then the engine preference.
+// Whichever wins may still be a sentinel (EqualsOutput, Reported) that needs the recording context to resolve.
+// The fixtures are deliberately far apart so that a case cannot pass by resolving to the wrong one of them.
+
+const outputLatency = 0.05
+const reportedLatency = 0.02
+const preferredLatency = 0.005
+const overriddenLatency = 0.03
+
+describe("InputLatency.Reported", () => {
+    it("is the lower bound the engine-preferences schema enforces", () => {
+        // The adapters package cannot import this namespace, so it repeats the number. Pin them together.
+        expect(EngineSettings.InputLatencyMinimum).toBe(InputLatency.Reported)
+    })
+})
+
+describe("InputLatency.resolve", () => {
+    it("applies the reported latency when the preference is Reported and the override inherits", () => {
+        expect(InputLatency.resolve(InputLatency.Inherit, InputLatency.Reported, outputLatency, reportedLatency))
+            .toBe(reportedLatency)
+    })
+    it("falls back to zero when the browser reports no latency", () => {
+        expect(InputLatency.resolve(InputLatency.Inherit, InputLatency.Reported, outputLatency, undefined)).toBe(0.0)
+    })
+    it("falls back to zero when the reported latency argument is omitted", () => {
+        expect(InputLatency.resolve(InputLatency.Inherit, InputLatency.Reported, outputLatency)).toBe(0.0)
+    })
+    it("falls back to zero when the browser reports a zero latency", () => {
+        expect(InputLatency.resolve(InputLatency.Inherit, InputLatency.Reported, outputLatency, 0.0)).toBe(0.0)
+    })
+    it("falls back to zero when the browser reports a value that is not a number", () => {
+        expect(InputLatency.resolve(InputLatency.Inherit, InputLatency.Reported, outputLatency, Number.NaN)).toBe(0.0)
+    })
+    it("falls back to zero when the browser reports an infinite latency", () => {
+        expect(InputLatency.resolve(InputLatency.Inherit, InputLatency.Reported, outputLatency, Number.POSITIVE_INFINITY))
+            .toBe(0.0)
+    })
+    it("prefers a numeric per-capture override over a Reported preference", () => {
+        expect(InputLatency.resolve(overriddenLatency, InputLatency.Reported, outputLatency, reportedLatency))
+            .toBe(overriddenLatency)
+    })
+    it("resolves a per-capture Reported override without inheriting the preference", () => {
+        // Discriminates "=== Inherit" from "<= Inherit": the latter would read the preference instead.
+        expect(InputLatency.resolve(InputLatency.Reported, preferredLatency, outputLatency, reportedLatency))
+            .toBe(reportedLatency)
+    })
+    it("clamps a per-capture value below Inherit instead of inheriting the preference", () => {
+        // Also discriminates "=== Inherit" from "<= Inherit", for a value that is no sentinel at all.
+        expect(InputLatency.resolve(-2.5, preferredLatency, outputLatency, reportedLatency)).toBe(0.0)
+    })
+    it("resolves a per-capture EqualsOutput to the output latency", () => {
+        expect(InputLatency.resolve(InputLatency.EqualsOutput, preferredLatency, outputLatency, reportedLatency))
+            .toBe(outputLatency)
+    })
+    it("resolves a preferred EqualsOutput to the output latency", () => {
+        expect(InputLatency.resolve(InputLatency.Inherit, InputLatency.EqualsOutput, outputLatency, reportedLatency))
+            .toBe(outputLatency)
+    })
+    it("uses a numeric preference verbatim", () => {
+        expect(InputLatency.resolve(InputLatency.Inherit, preferredLatency, outputLatency, reportedLatency))
+            .toBe(preferredLatency)
+    })
+    it("resolves a stray Inherit stored in the preference to zero", () => {
+        expect(InputLatency.resolve(InputLatency.Inherit, InputLatency.Inherit, outputLatency, reportedLatency))
+            .toBe(0.0)
+    })
+    it("clamps a negative value that is not a sentinel to zero", () => {
+        expect(InputLatency.resolve(-0.5, preferredLatency, outputLatency, reportedLatency)).toBe(0.0)
+        expect(InputLatency.resolve(InputLatency.Inherit, -0.5, outputLatency, reportedLatency)).toBe(0.0)
+    })
+})
+
+describe("InputLatency.resolveWithSource", () => {
+    it("names the reported source when the reported latency is usable", () => {
+        expect(InputLatency.resolveWithSource(InputLatency.Inherit, InputLatency.Reported, outputLatency, reportedLatency))
+            .toEqual({seconds: reportedLatency, source: "reported"})
+    })
+    it("names the unavailable source when the browser reports nothing", () => {
+        expect(InputLatency.resolveWithSource(InputLatency.Inherit, InputLatency.Reported, outputLatency, undefined))
+            .toEqual({seconds: 0.0, source: "reported-unavailable"})
+    })
+    it("names the unavailable source when the reported latency argument is omitted", () => {
+        expect(InputLatency.resolveWithSource(InputLatency.Inherit, InputLatency.Reported, outputLatency))
+            .toEqual({seconds: 0.0, source: "reported-unavailable"})
+    })
+    it("names the unavailable source when the browser reports zero", () => {
+        expect(InputLatency.resolveWithSource(InputLatency.Inherit, InputLatency.Reported, outputLatency, 0.0))
+            .toEqual({seconds: 0.0, source: "reported-unavailable"})
+    })
+    it("names the unavailable source when the browser reports an infinite latency", () => {
+        expect(InputLatency.resolveWithSource(
+            InputLatency.Inherit, InputLatency.Reported, outputLatency, Number.POSITIVE_INFINITY))
+            .toEqual({seconds: 0.0, source: "reported-unavailable"})
+    })
+    it("names the capture source for a numeric per-capture override", () => {
+        expect(InputLatency.resolveWithSource(overriddenLatency, InputLatency.Reported, outputLatency, reportedLatency))
+            .toEqual({seconds: overriddenLatency, source: "capture"})
+    })
+    it("names the reported source for a per-capture Reported override", () => {
+        // Discriminates "=== Inherit" from "<= Inherit": the latter would report the preference instead.
+        expect(InputLatency.resolveWithSource(InputLatency.Reported, preferredLatency, outputLatency, reportedLatency))
+            .toEqual({seconds: reportedLatency, source: "reported"})
+    })
+    it("names the capture source for a per-capture value below Inherit", () => {
+        expect(InputLatency.resolveWithSource(-2.5, preferredLatency, outputLatency, reportedLatency))
+            .toEqual({seconds: 0.0, source: "capture"})
+    })
+    it("names the equals-output source for a per-capture EqualsOutput", () => {
+        expect(InputLatency.resolveWithSource(
+            InputLatency.EqualsOutput, preferredLatency, outputLatency, reportedLatency))
+            .toEqual({seconds: outputLatency, source: "equals-output"})
+    })
+    it("names the equals-output source for a preferred EqualsOutput", () => {
+        expect(InputLatency.resolveWithSource(
+            InputLatency.Inherit, InputLatency.EqualsOutput, outputLatency, reportedLatency))
+            .toEqual({seconds: outputLatency, source: "equals-output"})
+    })
+    it("names the preference source for a numeric preference", () => {
+        expect(InputLatency.resolveWithSource(InputLatency.Inherit, preferredLatency, outputLatency, reportedLatency))
+            .toEqual({seconds: preferredLatency, source: "preference"})
+    })
+    it("names the preference source for a stray Inherit stored in the preference", () => {
+        expect(InputLatency.resolveWithSource(
+            InputLatency.Inherit, InputLatency.Inherit, outputLatency, reportedLatency))
+            .toEqual({seconds: 0.0, source: "preference"})
+    })
+    it("names the capture source for a clamped negative per-capture override", () => {
+        expect(InputLatency.resolveWithSource(-0.5, preferredLatency, outputLatency, reportedLatency))
+            .toEqual({seconds: 0.0, source: "capture"})
+    })
+})

--- a/packages/studio/core/src/capture/InputLatency.test.ts
+++ b/packages/studio/core/src/capture/InputLatency.test.ts
@@ -39,6 +39,16 @@ describe("InputLatency.resolve", () => {
         expect(InputLatency.resolve(InputLatency.Inherit, InputLatency.Reported, outputLatency, Number.POSITIVE_INFINITY))
             .toBe(0.0)
     })
+    it("applies a reported latency that sits exactly on the ceiling", () => {
+        expect(InputLatency.resolve(
+            InputLatency.Inherit, InputLatency.Reported, outputLatency, InputLatency.ReportedMaximum))
+            .toBe(InputLatency.ReportedMaximum)
+    })
+    it("falls back to zero when the reported latency exceeds the ceiling", () => {
+        expect(InputLatency.resolve(
+            InputLatency.Inherit, InputLatency.Reported, outputLatency, InputLatency.ReportedMaximum + 0.001))
+            .toBe(0.0)
+    })
     it("prefers a numeric per-capture override over a Reported preference", () => {
         expect(InputLatency.resolve(overriddenLatency, InputLatency.Reported, outputLatency, reportedLatency))
             .toBe(overriddenLatency)
@@ -95,6 +105,16 @@ describe("InputLatency.resolveWithSource", () => {
         expect(InputLatency.resolveWithSource(
             InputLatency.Inherit, InputLatency.Reported, outputLatency, Number.POSITIVE_INFINITY))
             .toEqual({seconds: 0.0, source: "reported-unavailable"})
+    })
+    it("names the reported source for a latency that sits exactly on the ceiling", () => {
+        expect(InputLatency.resolveWithSource(
+            InputLatency.Inherit, InputLatency.Reported, outputLatency, InputLatency.ReportedMaximum))
+            .toEqual({seconds: InputLatency.ReportedMaximum, source: "reported"})
+    })
+    it("names the out-of-range source for a latency above the ceiling", () => {
+        expect(InputLatency.resolveWithSource(
+            InputLatency.Inherit, InputLatency.Reported, outputLatency, InputLatency.ReportedMaximum + 0.001))
+            .toEqual({seconds: 0.0, source: "reported-out-of-range"})
     })
     it("names the capture source for a numeric per-capture override", () => {
         expect(InputLatency.resolveWithSource(overriddenLatency, InputLatency.Reported, outputLatency, reportedLatency))

--- a/packages/studio/core/src/capture/InputLatency.ts
+++ b/packages/studio/core/src/capture/InputLatency.ts
@@ -1,17 +1,46 @@
+import {isDefined} from "@opendaw/lib-std"
+
 export namespace InputLatency {
     /** Per-track override sentinel: inherit the value from the engine preferences. */
     export const Inherit = -2.0
     /** Treat the input latency as equal to the output latency (doubles the compensation). */
     export const EqualsOutput = -1.0
+    /** Use the latency that the capture's own MediaStreamTrack reports, or none if the browser reports none. */
+    export const Reported = -3.0
+
+    /** Names the rule that produced a resolved input latency. */
+    export type Source = "capture" | "preference" | "equals-output" | "reported" | "reported-unavailable"
+
+    /** A resolved input latency in seconds together with the rule that produced it. */
+    export type Resolution = { seconds: number, source: Source }
 
     /**
      * Resolves the additional latency (in seconds) to add to the output latency when recording.
      * @param localOverride the per-track value stored in the CaptureAudioBox
      * @param preference the engine-preferences default
      * @param outputLatency the current output latency in seconds
+     * @param reportedLatency the latency the capture's MediaStreamTrack reports; omit it when the browser
+     *  reports none, which resolves the Reported sentinel to no compensation
      */
-    export const resolve = (localOverride: number, preference: number, outputLatency: number): number => {
-        const value = localOverride <= Inherit ? preference : localOverride
-        return value === EqualsOutput ? outputLatency : Math.max(0, value)
+    export const resolve = (localOverride: number,
+                            preference: number,
+                            outputLatency: number,
+                            reportedLatency?: number): number =>
+        resolveWithSource(localOverride, preference, outputLatency, reportedLatency).seconds
+
+    /** Resolves as {@link resolve} does and additionally names which rule won, for diagnostics. */
+    export const resolveWithSource = (localOverride: number,
+                                      preference: number,
+                                      outputLatency: number,
+                                      reportedLatency?: number): Resolution => {
+        const inherits = localOverride === Inherit
+        const value = inherits ? preference : localOverride
+        if (value === EqualsOutput) {return {seconds: outputLatency, source: "equals-output"}}
+        if (value === Reported) {
+            return isDefined(reportedLatency) && Number.isFinite(reportedLatency) && reportedLatency > 0.0
+                ? {seconds: reportedLatency, source: "reported"}
+                : {seconds: 0.0, source: "reported-unavailable"}
+        }
+        return {seconds: Math.max(0.0, value), source: inherits ? "preference" : "capture"}
     }
 }

--- a/packages/studio/core/src/capture/InputLatency.ts
+++ b/packages/studio/core/src/capture/InputLatency.ts
@@ -1,4 +1,4 @@
-import {isDefined} from "@opendaw/lib-std"
+import {isDefined, Optional} from "@opendaw/lib-std"
 
 export namespace InputLatency {
     /** Per-track override sentinel: inherit the value from the engine preferences. */
@@ -7,9 +7,15 @@ export namespace InputLatency {
     export const EqualsOutput = -1.0
     /** Use the latency that the capture's own MediaStreamTrack reports, or none if the browser reports none. */
     export const Reported = -3.0
+    /**
+     * Ceiling for a reported latency, in seconds. Input latency is tens of milliseconds; a report near a
+     * second is a misreport, and applying it would shift the take and its waveform by that much.
+     */
+    export const ReportedMaximum = 1.0
 
     /** Names the rule that produced a resolved input latency. */
-    export type Source = "capture" | "preference" | "equals-output" | "reported" | "reported-unavailable"
+    export type Source =
+        "capture" | "preference" | "equals-output" | "reported" | "reported-unavailable" | "reported-out-of-range"
 
     /** A resolved input latency in seconds together with the rule that produced it. */
     export type Resolution = { seconds: number, source: Source }
@@ -25,21 +31,25 @@ export namespace InputLatency {
     export const resolve = (localOverride: number,
                             preference: number,
                             outputLatency: number,
-                            reportedLatency?: number): number =>
+                            reportedLatency: Optional<number> = undefined): number =>
         resolveWithSource(localOverride, preference, outputLatency, reportedLatency).seconds
 
     /** Resolves as {@link resolve} does and additionally names which rule won, for diagnostics. */
     export const resolveWithSource = (localOverride: number,
                                       preference: number,
                                       outputLatency: number,
-                                      reportedLatency?: number): Resolution => {
+                                      reportedLatency: Optional<number> = undefined): Resolution => {
         const inherits = localOverride === Inherit
         const value = inherits ? preference : localOverride
         if (value === EqualsOutput) {return {seconds: outputLatency, source: "equals-output"}}
         if (value === Reported) {
-            return isDefined(reportedLatency) && Number.isFinite(reportedLatency) && reportedLatency > 0.0
-                ? {seconds: reportedLatency, source: "reported"}
-                : {seconds: 0.0, source: "reported-unavailable"}
+            if (!isDefined(reportedLatency) || !Number.isFinite(reportedLatency) || reportedLatency <= 0.0) {
+                return {seconds: 0.0, source: "reported-unavailable"}
+            }
+            if (reportedLatency > ReportedMaximum) {
+                return {seconds: 0.0, source: "reported-out-of-range"}
+            }
+            return {seconds: reportedLatency, source: "reported"}
         }
         return {seconds: Math.max(0.0, value), source: inherits ? "preference" : "capture"}
     }


### PR DESCRIPTION
### Problem

The input path has its own delay between the microphone and the recording worklet, on top of
the output latency that recording already compensates. The only way to compensate it today is to
type a number into the "Input latency" engine preference, which means measuring it by hand; a
value left at zero leaves the delay uncompensated on every recording.

The browser usually knows the number. `MediaStreamTrack.getSettings().latency` reports it, and
`CaptureAudio` already logs it as `inputLatencyReported` in its latency report — it was just
never used for anything.

### Change

A third `InputLatency` sentinel, `Reported` (`-3`), meaning "use the latency this capture's own
`MediaStreamTrack` reports", and it becomes the engine preference's default.

Resolution order is unchanged in shape: a per-capture `CaptureAudioBox.inputLatency` override
wins unless it is `Inherit`, otherwise the engine preference decides. Whichever value wins is
then interpreted — `EqualsOutput` still means the output latency, `Reported` means the reported
latency, anything else is clamped to a non-negative number of seconds.

The inherit check moves from `<= Inherit` to `=== Inherit` so a third, more negative sentinel
cannot be mistaken for `Inherit`. `resolveWithSource()` returns the resolved seconds together
with the name of the rule that won, and `CaptureAudio` logs that name in its latency report, so
"why is my recording offset by X" can be answered from the console. `resolve()` is unchanged for
existing callers apart from an optional fourth argument, the reported latency, declared as
`reportedLatency: Optional<number> = undefined` with the `lib-std` alias; omitting it resolves
`Reported` to no compensation.

The reported value is bounded: it is applied only when finite and within
`InputLatency.ReportedMaximum` (1 second — real input latency is tens of milliseconds), and
anything above resolves to no compensation, the same result an unreported latency gives. That
case carries its own `reported-out-of-range` source so the latency report still tells a
misreporting device apart from a silent one.

The preference schema's lower bound and default both come from one named constant, exported as
`EngineSettings.InputLatencyMinimum`. Because the new default sits on that bound and the
preferences panel edits the field as free text with an arrow-key step of 1, the panel gains
per-field value guards — the same shape as its existing per-field select options — and clamps
this input. Without that, one arrow-down stores `-4`, which fails the schema and costs the user
the whole recording section on the next load. The same guard covers `metronome.gain`, the other
numeric preference whose schema rejects values the input could step into. The panel label now
spells out the two sentinels.

New unit test `InputLatency.test.ts` covers every branch of the resolution, including the ones
that existed before, the value exactly on the ceiling and just above it, and pins the schema's
bound to the sentinel so the two cannot drift. `studio-core` is at 44 files / 432 tests.

### Behaviour for existing users

Nothing changes. Stored preferences are parsed against the schema, and a widened numeric
constraint cannot invalidate a previously-valid value, so an existing `inputLatency` — `0` for
anyone who never touched it — is kept verbatim. Only settings that have never been written pick
up the new default.

A user on the new default whose browser reports no latency, or reports zero, gets `0`
compensation, which is exactly what they got before.

### Limits

The compensation is only as good as the number the browser hands over. `getSettings().latency`
is optional in the Media Capture spec, browsers differ in whether they populate it and in what
it is supposed to cover, and it is not verifiable from inside the page. This change trusts it
when it is a finite value greater than zero and falls back to the old behaviour otherwise.

A synthetic loopback harness cannot exercise this path either: a generated stream reports no
hardware latency, so the fallback is all such a harness ever measures. Real verification needs a
real input device.

Refs #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using browser-reported input latency during audio capture.
  * Preferences now explain input-latency modes, including output-latency and reported-latency options.
  * Added safeguards that keep metronome gain and input latency within supported ranges.
  * Capture diagnostics now identify how applied input latency was determined.

* **Bug Fixes**
  * Improved input-latency resolution for missing, invalid, inherited, and reported values.
  * Reported latency outside supported limits now falls back safely to zero compensation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
