### PR TITLE
fix(capture): compensate MIDI note placement at write time, drop the 10-second fallback (#379)

### DIFF
--- a/packages/studio/core/src/capture/RecordMidi.test.ts
+++ b/packages/studio/core/src/capture/RecordMidi.test.ts
@@ -1,0 +1,24 @@
+import {describe, expect, it} from "vitest"
+import {PPQN} from "@opendaw/lib-dsp"
+import {RecordMidi} from "./RecordMidi"
+
+describe("RecordMidi.latencyInPulses (#379)", () => {
+    it("converts a browser-reported output latency to pulses at the given tempo", () => {
+        expect(RecordMidi.latencyInPulses(0.02, 120)).toBe(PPQN.secondsToPulses(0.02, 120))
+    })
+
+    it("compensates by nothing when outputLatency is unavailable, not by ten seconds", () => {
+        // Safari and iOS before 18.4 do not implement outputLatency. The old `?? 10.0` placed every note
+        // ~20 beats (five bars at 120 bpm) late; the fallback must be no compensation.
+        expect(RecordMidi.latencyInPulses(undefined, 120)).toBe(0)
+    })
+
+    it("uses the current tempo, so a faster tempo yields a larger pulse offset", () => {
+        expect(RecordMidi.latencyInPulses(0.02, 60)).toBe(PPQN.secondsToPulses(0.02, 60))
+        expect(RecordMidi.latencyInPulses(0.02, 140)).toBeGreaterThan(RecordMidi.latencyInPulses(0.02, 60))
+    })
+
+    it("treats an explicit zero as zero (output not yet running)", () => {
+        expect(RecordMidi.latencyInPulses(0, 120)).toBe(0)
+    })
+})

--- a/packages/studio/core/src/capture/RecordMidi.ts
+++ b/packages/studio/core/src/capture/RecordMidi.ts
@@ -5,6 +5,7 @@ import {
     Notifier,
     Nullable,
     Option,
+    Optional,
     quantizeCeil,
     quantizeFloor,
     Terminable,
@@ -39,6 +40,13 @@ export namespace RecordMidi {
 
     const MIN_NOTE_DURATION = PPQN.fromSignature(1, 128)
 
+    // Compensate note placement for the engine-to-speaker output latency. `AudioContext.outputLatency` is
+    // undefined on browsers that do not implement it (Safari and iOS before 18.4); when it is missing we
+    // compensate by nothing rather than by a fixed guess, since the true value is device-specific and unknown.
+    // The old code fell back to `10.0`, read as seconds, which placed every recorded note about five bars late.
+    export const latencyInPulses = (outputLatency: Optional<number>, bpm: number): ppqn =>
+        PPQN.secondsToPulses(outputLatency ?? 0.0, bpm)
+
     export const start = ({notifier, project, capture}: RecordMidiContext): Terminable => {
         const beats = PPQN.fromSignature(1, project.timelineBox.signature.denominator.getValue())
         const {editing, boxGraph, engine, env: {audioContext}, timelineBox} = project
@@ -47,7 +55,9 @@ export namespace RecordMidi {
         const terminator = new Terminator()
         const activeNotes = new Map<byte, ActiveNote>()
         const pendingNotes = new Map<byte, byte>()
-        const latency = PPQN.secondsToPulses(audioContext.outputLatency ?? 10.0, timelineBox.bpm.getValue())
+        // Read the output latency and tempo at write time, not once here: the browser reports 0 for
+        // outputLatency until output is running, and the tempo can change during the recording (#379).
+        const currentLatency = (): ppqn => latencyInPulses(audioContext.outputLatency, timelineBox.bpm.getValue())
         let currentTake: Option<TakeData> = Option.None
         let lastPosition: ppqn = 0
         let positionOffset: ppqn = 0
@@ -132,7 +142,7 @@ export namespace RecordMidi {
         terminator.own(position.catchupAndSubscribe(owner => {
             if (!isRecording.getValue()) {return}
             const currentPosition = owner.getValue()
-            const writePosition = currentPosition + latency
+            const writePosition = currentPosition + currentLatency()
             const loopEnabled = loopArea.enabled.getValue()
             const loopFrom = loopArea.from.getValue()
             const loopTo = loopArea.to.getValue()
@@ -189,7 +199,7 @@ export namespace RecordMidi {
         }))
 
         terminator.ownAll(notifier.subscribe((signal: NoteSignal) => {
-            const writePosition = position.getValue() + latency
+            const writePosition = position.getValue() + currentLatency()
             if (NoteSignal.isOn(signal)) {
                 const {pitch, velocity} = signal
                 if (currentTake.isEmpty()) {


### PR DESCRIPTION
Fixes #379.

`RecordMidi.start` computed the output-latency offset once, at record start, and added it to every recorded note:

```ts
const latency = PPQN.secondsToPulses(audioContext.outputLatency ?? 10.0, timelineBox.bpm.getValue())
```

There are three problems in that line, all of which naomiaro laid out in the issue:

1. **The fallback is ten seconds.** `AudioContext.outputLatency` is undefined on browsers that do not implement it (Safari and iOS before 18.4), so `?? 10.0` is read as seconds and places every recorded note about five bars late at 120 bpm. It was clearly meant to be a small default in milliseconds.
2. **It is read once, before output is running.** Chrome reports `0` for `outputLatency` until audio is actually being rendered to the device, so the first take of a session gets no compensation while later takes in the same session do.
3. **The tempo is read once too,** so the pulse offset is wrong for any tempo change during the recording.

## Fix

Move the read to write time through a small exported helper, called for each position update and each note-on:

```ts
export const latencyInPulses = (outputLatency: Optional<number>, bpm: number): ppqn =>
    PPQN.secondsToPulses(outputLatency ?? 0.0, bpm)
```

Reading fresh fixes (2) and (3); the fallback fixes (1). When `outputLatency` is unavailable I chose to compensate by **nothing** rather than a fixed guess, because the true value is device-specific and a wrong device-wide constant is what caused the original bug. If you would rather have a small millisecond default there, that is a one-value change. Happy to go the other way.

Note on scope: the read-once pattern here mirrors the audio path that #376 addressed; this is the MIDI-side equivalent, kept to `RecordMidi`.

## Verification

- New `RecordMidi.test.ts` covers the conversion, the tempo dependence, and the missing-`outputLatency` fallback. Proven RED on the old `?? 10.0` (the fallback test fails, placing the note ~20 beats out), GREEN on the fix.
- Full `@opendaw/studio-core` suite green, `tsc --noEmit` clean.
- Built `studio-core` and booted the studio to confirm the change loads and runs with no console errors. The Safari-specific symptom (undefined `outputLatency`) cannot be reproduced in Chromium, where the property is present, so a live recording there would behave the same before and after; the unit test is the deterministic proof of the fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MIDI recording timing by recalculating audio latency and tempo when notes are written.
  - MIDI recordings now receive more accurate timing compensation across different tempos.
  - When audio latency is unavailable, recording uses zero compensation instead of a fixed fallback value.

- **Tests**
  - Added coverage for latency conversion at different tempos, zero latency, and unavailable-latency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->